### PR TITLE
ensure Msal2Provider is initialized first

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,20 +1,8 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { AppInsightsContext } from "@microsoft/applicationinsights-react-js";
-import App from "./App";
-import "./index.css";
-import { MsalProvider } from "@azure/msal-react";
-import { msalInstance } from "./services/auth";
-import { MsalAuthenticationTemplate } from "@azure/msal-react";
-import { reactPlugin } from "./utils/appinsights";
-import { InteractionType } from "@azure/msal-browser";
-import { Providers } from "@microsoft/mgt";
+import { Providers, ProviderState } from "@microsoft/mgt";
 import { Msal2Provider } from "@microsoft/mgt-msal2-provider";
 import { config } from "./config/Settings";
 
-const queryClient = new QueryClient();
-
+// Initialize Msal2Provider before any other imports or component rendering
 try {
     Providers.globalProvider = new Msal2Provider({
         clientId: config.clientId || "",
@@ -27,6 +15,38 @@ try {
 } catch (error) {
     console.log("Error initializing Msal2Provider:", error);
 }
+
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AppInsightsContext } from "@microsoft/applicationinsights-react-js";
+import App from "./App";
+import "./index.css";
+import { MsalProvider } from "@azure/msal-react";
+import { msalInstance } from "./services/auth";
+import { MsalAuthenticationTemplate } from "@azure/msal-react";
+import { reactPlugin } from "./utils/appinsights";
+import { InteractionType } from "@azure/msal-browser";
+
+const queryClient = new QueryClient();
+
+const checkProviderState = () => {
+    const provider = Providers.globalProvider;
+    if (provider) {
+        console.log("Provider state:", provider.state);
+        if (provider.state === ProviderState.SignedIn) {
+            console.log("Provider is signed in");
+        } else if (provider.state === ProviderState.SignedOut) {
+            console.log("Provider is signed out");
+        } else if (provider.state === ProviderState.Loading) {
+            console.log("Provider is loading");
+        }
+    } else {
+        console.error("Provider not initialized");
+    }
+};
+
+checkProviderState();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>


### PR DESCRIPTION
Msal2provider works locally but not on server.

Ensure that Msal2Provider is initialized correctly and at the right time. It should be initialized before any authentication attempts are made.

