### PR TITLE
Remove CO2 from FormConfig

### DIFF
--- a/frontend/src/dto/FormConfig.tsx
+++ b/frontend/src/dto/FormConfig.tsx
@@ -154,13 +154,6 @@ export const getFormConfig = (model: string): FormConfig => {
                     input_type: "textbox",
                     enabled: false,
                 },
-                CO2: {
-                    defaultvalue: 1,
-                    meta: "ppm",
-                    type: "float",
-                    input_type: "textbox",
-                    enabled: true,
-                },
                 H2O: {
                     defaultvalue: 20,
                     meta: "ppm",


### PR DESCRIPTION
In Arcs, if CO2 is part of the input, it is
deleted either way. Also, it is misleading
in the frontend that CO2 concentration can be
edited, as CO2 concentration would always be
present and much higher than the other impurities.

Ref: traverse()
if "CO2" in concstring:
        del concstring["CO2"]

Fixes #86 