### PR TITLE
Add subscripts to reactions

### DIFF
--- a/frontend/src/pages/Reactions.tsx
+++ b/frontend/src/pages/Reactions.tsx
@@ -20,6 +20,23 @@ const Reactions: React.FC<ResultsProps> = ({ simulationResults }) => {
     common_paths = simulationResults.analysis.common_paths;
     reactions = simulationResults.analysis.stats;
 
+    const convertToSubscripts = (chemicalFormula: string): string => {
+        const subscriptMap: { [key: string]: string } = {
+            "0": "<sub>0</sub>",
+            "1": "<sub>1</sub>",
+            "2": "<sub>2</sub>",
+            "3": "<sub>3</sub>",
+            "4": "<sub>4</sub>",
+            "5": "<sub>5</sub>",
+            "6": "<sub>6</sub>",
+            "7": "<sub>7</sub>",
+            "8": "<sub>8</sub>",
+            "9": "<sub>9</sub>",
+        };
+
+        return chemicalFormula.replace(/(?<=\p{L})\d|(?=\p{L})\d/gu, (digit: string) => subscriptMap[digit]);
+    };
+
     return (
         <div>
             <br />
@@ -36,7 +53,9 @@ const Reactions: React.FC<ResultsProps> = ({ simulationResults }) => {
                 <Table.Body>
                     {Object.keys(reactions.index).map((key, index) => (
                         <Table.Row key={index}>
-                            <Table.Cell dangerouslySetInnerHTML={{ __html: reactions.index[key] }} />
+                            <Table.Cell
+                                dangerouslySetInnerHTML={{ __html: convertToSubscripts(reactions.index[key]) }}
+                            />
                             <Table.Cell>{reactions.k[key]}</Table.Cell>
                             <Table.Cell>{reactions.frequency[key]}</Table.Cell>
                         </Table.Row>


### PR DESCRIPTION
We added subscripts to input fields, however it reduced readability (at least until we figure out how to increase font size). Also, the subscript sizes were inconsistent, and <sub/sub> notation did not convert to proper subscript for input fields.
We checked Excel files, and they usually don't use subscripts for compound names, except for in reactions. Therefore, we added subscripts to the reactions instead.

Fixes #112
