### PR TITLE
Fix clickbox size

### DIFF
--- a/frontend/src/pages/ResultsPage.tsx
+++ b/frontend/src/pages/ResultsPage.tsx
@@ -93,20 +93,23 @@ const ResultsPage: React.FC = () => {
     return (
         <>
             <h1>Results</h1>
-            <label style={{ display: 'flex', alignItems: 'center' }}>
+            <div style={{ display: 'flex', alignItems: 'center' }}>
                 <input
-                type="checkbox"
-                checked={enableFilters}
-                onChange={handleEnableFilters}
-                style={{
-                    transform: 'scale(1.5)',
-                    marginBottom: '20px'
-                }}
+                    type="checkbox"
+                    checked={enableFilters}
+                    onChange={handleEnableFilters}
+                    style={{
+                        transform: 'scale(1.5)',
+                        marginBottom: '20px'
+                    }}
                 />
-                <span style={{ fontSize: '18px', marginLeft: '8px' , marginBottom: "17px"}}>
-                    {"Enable filters"}
+                <span 
+                    onClick={handleEnableFilters} 
+                    style={{ fontSize: '18px', marginLeft: '8px', marginBottom: "17px", cursor: 'pointer' }}
+                >
+                    Enable filters
                 </span>
-            </label>            
+            </div>            
             <EdsDataGrid columns={columns} rows={rows} enableColumnFiltering={enableFilters} />;
         </>
     )


### PR DESCRIPTION
The enable filters box could be enabled/disabled by clicking the whole whitespace in the same row, which led to misclicks and unintended behaviour.