### PR TITLE
Make consistent project/simulation access

### DIFF
--- a/frontend/src/components/SaveResultButton.tsx
+++ b/frontend/src/components/SaveResultButton.tsx
@@ -3,9 +3,12 @@ import { getProjects, saveResult, saveSimulation } from "../api/api";
 import { FormConfig } from "../dto/FormConfig";
 import { SimulationResults } from "../dto/SimulationResults";
 import { Autocomplete, Button, Checkbox, TextField } from "@equinor/eds-core-react";
-import { useEffect, useState } from "react";
+import { SetStateAction, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useErrorStore } from "../hooks/useErrorState";
+import CreateProjectDialog from "./CreateProjectDialog";
+import { useAccount } from "@azure/msal-react";
+import { Project } from "../dto/Project";
 
 interface SimulationProps {
     formConfig: FormConfig;
@@ -21,10 +24,21 @@ const SaveResultButton: React.FC<{ props: SimulationProps }> = ({ props }) => {
     const [simulationName, setSimulationName] = useState<string>("");
     const [isSimulationSaving, setIsSimulationSaving] = useState<boolean>(false);
     const [isSimulationSaved, setIsSimulationSaved] = useState<boolean>(false);
-    const { data: projects, isLoading } = useQuery({
+    const [createScenarioDialogOpen, setCreateProjectDialogOpen] = useState(false);
+    const accountId = useAccount()?.localAccountId;
+    const {
+        data: projects,
+        isLoading,
+        error,
+    } = useQuery({
         queryKey: ["projects"],
         queryFn: getProjects,
     });
+    const [privateProjects, setPrivateProjects] = useState<Project[]>([]);
+
+    useEffect(() => {
+        if (projects) setPrivateProjects(projects.filter((project) => project.owner_id === accountId));
+    }, [projects]);
 
     useEffect(() => {
         setProjectName(projects?.find((proj) => proj.id === selectedProjectId)?.name || "");
@@ -62,28 +76,41 @@ const SaveResultButton: React.FC<{ props: SimulationProps }> = ({ props }) => {
         saveSimulationMutation.mutate(props);
     };
 
-    if (!projects) {
-        return <div>Cannot save simulation: Could not fetch projects.</div>;
+    if (isLoading) {
+        return <>Fetching projects ...</>;
+    }
+
+    if (error) {
+        return <>Cannot save simulation: Could not fetch projects.</>;
+    }
+
+    if (privateProjects.length === 0) {
+        return (
+            <div>
+                <div style={{ marginBottom: "10px" }}>You have projects this simulation can be saved to</div>
+                <div>
+                    <Button onClick={() => setCreateProjectDialogOpen(true)}>Create a new project?</Button>
+                </div>
+                {createScenarioDialogOpen && (
+                    <CreateProjectDialog setCreateProjectDialogOpen={setCreateProjectDialogOpen} />
+                )}
+            </div>
+        );
     }
 
     return (
         <>
-            {isLoading ? (
-                "Loading projects ..."
-            ) : !projects ? (
-                "Could not fetch projects"
-            ) : (
-                <Autocomplete
-                    label="Save to project:"
-                    options={projects.map((project) => project.name)}
-                    placeholder={projectName}
-                    disabled={isSimulationSaving}
-                    onOptionsChange={({ selectedItems }) => {
-                        setSelectedProjectId(projects.find((proj) => proj.name === selectedItems[0])?.id || "");
-                        setIsSimulationSaved(false);
-                    }}
-                />
-            )}
+            <Autocomplete
+                label="Save to project:"
+                options={privateProjects.map((project) => project.name)}
+                placeholder={projectName}
+                disabled={isSimulationSaving}
+                onOptionsChange={({ selectedItems }) => {
+                    setSelectedProjectId(projects!.find((proj) => proj.name === selectedItems[0])?.id || "");
+                    setIsSimulationSaved(false);
+                }}
+            />
+
             <TextField
                 id="simulation-name"
                 label="Simulation Name:"
@@ -95,8 +122,9 @@ const SaveResultButton: React.FC<{ props: SimulationProps }> = ({ props }) => {
                 }}
                 style={{ paddingBottom: "10px" }}
             />
+
             {isSimulationSaved ? (
-                `Saved simulation as "${simulationName}" to project "${projects.find((proj) => proj.id === selectedProjectId)?.name || ""}"`
+                `Saved simulation as "${simulationName}" to project "${projects!.find((proj) => proj.id === selectedProjectId)?.name || ""}"`
             ) : (
                 <Button
                     onClick={handleSave}

--- a/frontend/src/pages/ProjectList.tsx
+++ b/frontend/src/pages/ProjectList.tsx
@@ -15,7 +15,7 @@ const StyledRowLayout = styled.div`
 
 export default function ProjectList(): JSX.Element {
     const { data: projects, error, isLoading } = useQuery({ queryKey: ["projects"], queryFn: getProjects });
-    const yourProjects = projects ? projects.filter((project) => project.private === true) : [];
+    const privateProjects = projects ? projects.filter((project) => project.private === true) : [];
     const internalProjects = projects ? projects.filter((project) => project.private === false) : [];
     const [createScenarioDialogOpen, setCreateProjectDialogOpen] = useState(false);
 
@@ -36,7 +36,7 @@ export default function ProjectList(): JSX.Element {
             <StyledRowLayout>
                 {isLoading && <p>Loading projects...</p>}
                 {error && <p>Error: {String(error)}</p>}
-                {yourProjects?.length === 0 && internalProjects?.length === 0 ? (
+                {privateProjects?.length === 0 && internalProjects?.length === 0 ? (
                     <p>No projects available.</p>
                 ) : (
                     <Table style={{ width: "100%" }}>
@@ -54,7 +54,7 @@ export default function ProjectList(): JSX.Element {
                                     <Typography variant="overline">Private projects</Typography>
                                 </Table.Cell>
                             </Table.Row>
-                            <ProjectListContent projects={yourProjects} />
+                            <ProjectListContent projects={privateProjects} />
                             <Table.Row key="InternalProjectDivider">
                                 <Table.Cell colSpan={4}>
                                     <Typography variant="overline">Internal projects</Typography>


### PR DESCRIPTION
This change will:
-Only show projects the user own when prompting to save simulation 
-Prompt user to create new project if no such project exists 
-Remove "edit" buttons on projects you dont own
-Remove "new simulation" in projects you dont own

Did not receive a clear answer from users regarding editing each other's projects, so this will make it read only regarding other's projects and we will change it when users requests it. Per now we get errors when attempting to edit other peoples projects.

Solves #145
