### PR TITLE
Fix project endpoints auth

### DIFF
--- a/backend/src/acidwatch_api/project_endpoints.py
+++ b/backend/src/acidwatch_api/project_endpoints.py
@@ -2,11 +2,11 @@ import os
 import uuid
 from typing import Annotated, Any
 import jwt
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from pydantic import ValidationError
 
 from acidwatch_api import db_client, local_db
-from acidwatch_api.authentication import oauth2_scheme
+from acidwatch_api.authentication import oauth2_scheme, authenticated_user_claims
 from acidwatch_api.models.datamodel import Project, Scenario, Result
 import logging
 
@@ -25,7 +25,7 @@ if CONNECTION_STRING is None or CONNECTION_STRING == "local":
 else:
     project_db = db_client.DBClient(CONNECTION_STRING)
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(authenticated_user_claims)])
 
 
 @router.post("/project")


### PR DESCRIPTION
By adding Depends(authenticated_user_claims) as a global dependency to the router, all endpoints defined under this router will now require authentication via the authenticated_user_claims dependency