### PR TITLE
Move save result control and disable after save

### DIFF
--- a/frontend/src/components/SaveButton.tsx
+++ b/frontend/src/components/SaveButton.tsx
@@ -26,7 +26,7 @@ const SaveButton: React.FC<{
         <Tooltip title={toolTipString}>
             <Button
                 onClick={handleSave}
-                disabled={!validSimulationName || !validProjectId}
+                disabled={!validSimulationName || !validProjectId || isSimulationSaved}
                 //variant={!Boolean(selectedProjectId && simulationName) ? "ghost" : "contained"}
                 color={!isSimulationSaved ? "primary" : "secondary"}
             >

--- a/frontend/src/pages/InputForm.tsx
+++ b/frontend/src/pages/InputForm.tsx
@@ -181,12 +181,10 @@ const InputForm: React.FC = () => {
                         )}
                     </>
                 </form>
-            </div>
-            <div style={{ marginLeft: "100px" }}>
-                {isSimulationRunning && <img src={loader} alt="Loading" style={{ width: "70px" }} />}
                 {simulationResults && (
                     <>
-                        <h3>Save this simulation?</h3>
+                        <br />
+                        <b>Save result?</b>
                         {isAuthenticated ? (
                             <>
                                 <SaveResult
@@ -198,8 +196,15 @@ const InputForm: React.FC = () => {
                                 />
                             </>
                         ) : (
-                            <p>User is not authenticated. This simulation cannot be saved.</p>
+                            <p>User is not signed in. Result cannot be saved.</p>
                         )}
+                    </>
+                )}
+            </div>
+            <div style={{ marginLeft: "100px" }}>
+                {isSimulationRunning && <img src={loader} alt="Loading" style={{ width: "70px" }} />}
+                {simulationResults && (
+                    <>
                         <Results simulationResults={simulationResults} />
                     </>
                 )}


### PR DESCRIPTION
Disable the button after it is pressed and also moved the inputs to keep the results tabs fixed at top. Open for suggestions, it could also be a popup, but I find the current location above the results tab taking to much focus away from the results

<img width="758" height="1088" alt="image" src="https://github.com/user-attachments/assets/b3364796-122c-43cf-901a-ccfd2c00caa1" />