### PR TITLE
Use pyproject entry-points to discover models

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,3 +35,7 @@ profile = "black"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+
+[tool.poetry.plugins.acidwatch-model]
+arcs = "acidwatch_api.models.arcs:ArcsAdapter"
+tocomo = "acidwatch_api.models.co2spec:TocomoAdapter"

--- a/backend/src/acidwatch_api/app.py
+++ b/backend/src/acidwatch_api/app.py
@@ -28,8 +28,8 @@ from acidwatch_api.authentication import (
     get_jwt_token,
 )
 from acidwatch_api.models.base import (
-    ADAPTERS,
     BaseAdapter,
+    get_adapters,
     get_parameters_schema,
 )
 from acidwatch_api import _legacy
@@ -67,7 +67,7 @@ def get_models(
     jwt_token: str | None = Depends(get_jwt_token),
 ) -> dict[str, Any]:
     models: list[ModelInfo] = []
-    for adapter in ADAPTERS.values():
+    for adapter in get_adapters().values():
         access_error: str | None = (
             _check_auth(adapter, jwt_token) if adapter.authentication else None
         )
@@ -129,7 +129,7 @@ async def run_model(
     request: RunRequest,
     jwt_token: Annotated[str | None, Security(get_jwt_token)],
 ) -> SimulationResults:
-    adapter_class = ADAPTERS[model_id]
+    adapter_class = get_adapters()[model_id]
     adapter = adapter_class(request.concs, request.settings, jwt_token)
     result = await adapter.run()
     return _legacy.result_to_simulation_results(request.concs, result)

--- a/backend/src/acidwatch_api/models/__init__.py
+++ b/backend/src/acidwatch_api/models/__init__.py
@@ -1,4 +1,0 @@
-from . import co2spec, arcs, solubilityccs
-
-
-__all__ = ["arcs", "co2spec", "solubilityccs"]

--- a/backend/src/acidwatch_api/models/base.py
+++ b/backend/src/acidwatch_api/models/base.py
@@ -22,10 +22,8 @@ from pydantic.alias_generators import to_camel
 from pydantic.config import JsonDict
 from typing_extensions import Doc
 from pydantic import BaseModel, ConfigDict, Field, model_validator
-import inspect
-
-
-ADAPTERS: dict[str, type[BaseAdapter]] = {}
+import importlib.metadata
+from functools import lru_cache
 
 
 Compound: TypeAlias = str
@@ -172,14 +170,6 @@ class BaseAdapter:
                     f"{cls} declares field 'parameters', but it's not a subclass of BaseParameters"
                 )
 
-        # Automatically register adapter
-        if (other_cls := ADAPTERS.get(cls.model_id)) is not None:
-            raise ValueError(
-                f"Model adapter with ID '{cls.model_id}' has already been declared in {inspect.getfile(other_cls)}"
-            )
-
-        ADAPTERS[cls.model_id] = cls
-
     model_id: Annotated[str, Doc("Unique model identifier")]
     display_name: Annotated[
         str, Doc("User-friendly model name which is displayed in the frontend")
@@ -212,3 +202,17 @@ class BaseAdapter:
 
     async def run(self) -> RunResult:
         raise NotImplementedError()
+
+
+@lru_cache
+def get_adapters() -> dict[str, type[BaseAdapter]]:
+    adapters: dict[str, type[BaseAdapter]] = {}
+    for dist in importlib.metadata.distributions():
+        for entries in dist.entry_points:
+            if entries.group != "acidwatch-model":
+                continue
+
+            type_ = entries.load()
+            adapters[type_.model_id] = type_
+
+    return adapters

--- a/backend/tests/models/test_adapter.py
+++ b/backend/tests/models/test_adapter.py
@@ -4,24 +4,6 @@ import pytest
 from acidwatch_api.models import base
 
 
-@pytest.fixture(autouse=True)
-def no_adapters(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(base, "ADAPTERS", {})
-
-
-def test_subclass_is_automatically_registered():
-    # We have no pre-registered adapters
-    assert base.ADAPTERS == {}
-
-    class DummyAdapter(base.BaseAdapter):
-        model_id = "dummy"
-
-    # "dummy" is the only registered adapter
-    assert len(base.ADAPTERS) == 1
-    assert base.ADAPTERS["dummy"] is DummyAdapter
-    assert base._get_parameters_type(DummyAdapter) is None
-
-
 def test_parameters_class_must_contain_only_parameter_fields():
     # Pydantic handles this one
     with pytest.raises(TypeError, match="All model fields require a type annotation"):

--- a/backend/tests/models/test_all_adapters.py
+++ b/backend/tests/models/test_all_adapters.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import pytest
 import re
-from acidwatch_api.models.base import ADAPTERS, BaseAdapter
+from acidwatch_api.models.base import get_adapters, BaseAdapter
 
 
 SUBSTANCE_PATTERN = re.compile(
@@ -41,12 +41,12 @@ def _assert_is_valid_substance(substance: str) -> None:
             )
 
 
-@pytest.mark.parametrize("adapter", ADAPTERS.values())
+@pytest.mark.parametrize("adapter", get_adapters().values())
 def test_has_model_name(adapter: BaseAdapter):
     assert adapter.display_name.strip() != ""
 
 
-@pytest.mark.parametrize("adapter", ADAPTERS.values())
+@pytest.mark.parametrize("adapter", get_adapters().values())
 def test_init_concs(adapter: BaseAdapter):
     for substance in adapter.valid_substances:
         assert substance != "CO2", (

--- a/backend/tests/test_models_endpoints.py
+++ b/backend/tests/test_models_endpoints.py
@@ -21,4 +21,4 @@ def test_get_models():
     client = TestClient(fastapi_app)
     response = client.get("/models")
     assert response.status_code == 200
-    assert len(response.json()) == 3
+    assert len(response.json()) == 2


### PR DESCRIPTION
Instead of directly importing models, we can use Python's entry-points structure to dynamically find models when they're installed. This means that adding a new compatible model to AcidWatch requires the user to pip-install a package that defines a `acidwatch-model` entry-point.