### PR TITLE
Only show valid substances in Model inputs

### DIFF
--- a/frontend/src/components/ModelInputs.tsx
+++ b/frontend/src/components/ModelInputs.tsx
@@ -81,7 +81,9 @@ const ModelInputs: React.FC<{
     onSubmit: (concentrations: Record<string, number>, parameters: Record<string, number>) => void;
 }> = ({ model, visible: not_hidden, onSubmit }) => {
     const [concentrations, setConcentrations] = useState<Record<string, number>>(DEFAULTS);
-    const [visible, setVisible] = useState<string[]>(Object.keys(DEFAULTS));
+    const [visible, setVisible] = useState<string[]>(
+        Object.keys(DEFAULTS).filter((subs) => model.validSubstances.includes(subs))
+    );
     const [parameters, setParameters] = useState<Record<string, number>>(getParameterDefaults(model));
 
     if (!not_hidden) {


### PR DESCRIPTION
We have some default values, but not all adapters allow for these default inputs.