### PR TITLE
use valid_substances for defaults

### DIFF
--- a/frontend/src/components/ModelInputs.tsx
+++ b/frontend/src/components/ModelInputs.tsx
@@ -80,10 +80,12 @@ const ModelInputs: React.FC<{
     visible: boolean;
     onSubmit: (concentrations: Record<string, number>, parameters: Record<string, number>) => void;
 }> = ({ model, visible: not_hidden, onSubmit }) => {
-    const [concentrations, setConcentrations] = useState<Record<string, number>>(DEFAULTS);
-    const [visible, setVisible] = useState<string[]>(
-        Object.keys(DEFAULTS).filter((subs) => model.validSubstances.includes(subs))
+    const filteredDefaults = Object.fromEntries(
+        Object.entries(DEFAULTS).filter(([key]) => model.validSubstances.includes(key))
     );
+
+    const [concentrations, setConcentrations] = useState<Record<string, number>>(filteredDefaults);
+    const [visible, setVisible] = useState<string[]>(Object.keys(filteredDefaults));
     const [parameters, setParameters] = useState<Record<string, number>>(getParameterDefaults(model));
 
     if (!not_hidden) {


### PR DESCRIPTION
Not only for the list items is it necessary, but also for the
concentrations. Otherwise the default items will be included whenever we
call the adapter backend.
