### PR TITLE
Move plots in labresults

### DIFF
--- a/frontend/src/pages/LabResults.tsx
+++ b/frontend/src/pages/LabResults.tsx
@@ -172,7 +172,7 @@ const LabResults: React.FC = () => {
                     rowStyle={(row) => (row.id in selectedRows ? { backgroundColor: "lightblue" } : {})}
                 />
             </EdsProvider>
-            <Button onClick={() => setSelectedRows({})}>Deselect all</Button>
+            <Button onClick={() => setSelectedRows({})}>Clear</Button>
         </>
     );
 };

--- a/frontend/src/pages/LabResults.tsx
+++ b/frontend/src/pages/LabResults.tsx
@@ -143,9 +143,23 @@ const LabResults: React.FC = () => {
         <>
             <Typography variant="h1">Lab results</Typography>
             {issueRetrievingDataInfo}
-            <Typography variant="body_short">
-                Select rows to compare. Plots will appear at the bottom of the list
-            </Typography>
+            <>
+                <h2>Plot summary</h2>
+                <ResultScatterGraph graphData={rowRecord_to_ScatterGraphData(selectedRows)} />
+                <h2>Plot per component</h2>
+                <div style={{ width: "500px" }}>
+                    <Autocomplete
+                        label={"Select multiple components"}
+                        options={finalConcHeaders}
+                        multiple
+                        onOptionsChange={handlePlotComponentsChange}
+                    />
+                </div>
+                <ResultScatterGraph
+                    graphData={graphComponentsAndRowRecord_to_ScatterGraphData(selectedRows, plotComponents)}
+                />
+            </>
+            <Typography variant="body_short">Select rows to compare.</Typography>
             <EdsProvider density="compact">
                 <EdsDataGrid
                     columns={columns}
@@ -159,24 +173,6 @@ const LabResults: React.FC = () => {
                 />
             </EdsProvider>
             <Button onClick={() => setSelectedRows({})}>Deselect all</Button>
-            {Object.keys(selectedRows).length > 0 && (
-                <>
-                    <h2>Plot summary</h2>
-                    <ResultScatterGraph graphData={rowRecord_to_ScatterGraphData(selectedRows)} />
-                    <h2>Plot per component</h2>
-                    <div style={{ width: "500px" }}>
-                        <Autocomplete
-                            label={"Select multiple components"}
-                            options={finalConcHeaders}
-                            multiple
-                            onOptionsChange={handlePlotComponentsChange}
-                        />
-                    </div>
-                    <ResultScatterGraph
-                        graphData={graphComponentsAndRowRecord_to_ScatterGraphData(selectedRows, plotComponents)}
-                    />
-                </>
-            )}
         </>
     );
 };

--- a/frontend/src/pages/LabResults.tsx
+++ b/frontend/src/pages/LabResults.tsx
@@ -13,7 +13,6 @@ import { Autocomplete, AutocompleteChanges, Button, Card, EdsProvider, Typograph
 const LabResults: React.FC = () => {
     const initialPrefix = "in-";
     const finalPrefix = "out-";
-    const [enableFilters, setEnableFilters] = useState<boolean>(false);
     const [plotComponents, setPlotComponents] = useState<string[]>([]);
     const [selectedRows, setSelectedRows] = useState<
         Record<
@@ -121,10 +120,6 @@ const LabResults: React.FC = () => {
         meta: {},
     }));
 
-    const handleEnableFilters = () => {
-        setEnableFilters(!enableFilters);
-    };
-
     const handleRowClick = (
         row: Row<{
             meta: object;
@@ -151,28 +146,11 @@ const LabResults: React.FC = () => {
             <Typography variant="body_short">
                 Select rows to compare. Plots will appear at the bottom of the list
             </Typography>
-            <div style={{ display: "flex", alignItems: "center" }}>
-                <input
-                    type="checkbox"
-                    checked={enableFilters}
-                    onChange={handleEnableFilters}
-                    style={{
-                        transform: "scale(1.5)",
-                        marginBottom: "20px",
-                    }}
-                />
-                <span
-                    onClick={handleEnableFilters}
-                    style={{ fontSize: "18px", marginLeft: "8px", marginBottom: "17px", cursor: "pointer" }}
-                >
-                    Enable filters
-                </span>
-            </div>
             <EdsProvider density="compact">
                 <EdsDataGrid
                     columns={columns}
                     rows={rows}
-                    enableColumnFiltering={enableFilters}
+                    enableColumnFiltering={true}
                     enableMultiRowSelection
                     enableRowSelection
                     onRowClick={handleRowClick}

--- a/frontend/src/pages/LabResults.tsx
+++ b/frontend/src/pages/LabResults.tsx
@@ -144,9 +144,9 @@ const LabResults: React.FC = () => {
             <Typography variant="h1">Lab results</Typography>
             {issueRetrievingDataInfo}
             <>
-                <h2>Plot summary</h2>
+                <Typography variant="h2">Plot summary</Typography>
                 <ResultScatterGraph graphData={rowRecord_to_ScatterGraphData(selectedRows)} />
-                <h2>Plot per component</h2>
+                <Typography variant="h2">Plot per component</Typography>
                 <div style={{ width: "500px" }}>
                     <Autocomplete
                         label={"Select multiple components"}


### PR DESCRIPTION
I kinda dislike how the plots are shown below the list of experiments. For a short list it's kind of okay, for a long list the user isn't getting any feedback that they exist (other than the text, but not many reads those).

I wanted the first row to be selected, will try to get that to work. Would've wanted the EDS component to handle this for me, figured perhaps something like `selectedRows={{0:true}}` could be used..

This PR changes:
<img width="1764" height="1424" alt="Screenshot 2025-08-14 at 13 53 41" src="https://github.com/user-attachments/assets/7ce4e768-f5fd-4b1b-be0f-232c26cf4a37" />

into:
<img width="1764" height="1424" alt="Screenshot 2025-08-14 at 13 54 03" src="https://github.com/user-attachments/assets/8db7286f-0229-444f-b5b4-a8880763f09b" />


Edit: solves [#287](https://github.com/equinor/acidwatch/issues/287)