### PR TITLE
wip add on-the-fly sim results

### DIFF
--- a/backend/src/acidwatch_api/app.py
+++ b/backend/src/acidwatch_api/app.py
@@ -78,6 +78,7 @@ def get_models(
                 access_error=access_error,
                 model_id=adapter.model_id,
                 display_name=adapter.display_name,
+                category=adapter.category,
                 description=adapter.description,
                 valid_substances=adapter.valid_substances,
                 parameters=get_parameters_schema(adapter),

--- a/backend/src/acidwatch_api/models/arcs.py
+++ b/backend/src/acidwatch_api/models/arcs.py
@@ -38,6 +38,8 @@ class ArcsAdapter(BaseAdapter):
     model_id = "arcs"
     display_name = "ARCS"
     description = DESCRIPTION
+    category: str = "Primary"
+
     valid_substances = [
         "CH2O2",
         "CH3CH2OH",

--- a/backend/src/acidwatch_api/models/base.py
+++ b/backend/src/acidwatch_api/models/base.py
@@ -271,12 +271,22 @@ class BaseAdapter:
         ADAPTERS[cls.model_id] = cls
 
     model_id: Annotated[str, Doc("Unique model identifier")]
+
     display_name: Annotated[
         str, Doc("User-friendly model name which is displayed in the frontend")
     ]
+
     description: Annotated[
         str, Doc("A description for model which is displayed in the frontend")
     ]
+
+    category: Annotated[
+        str,
+        Doc(
+            "Category of the model, e.g., Primary (Inpedendent) or Secondary (Dependent)"
+        ),
+    ]
+
     valid_substances: Annotated[list[str], Doc("Substances that this model can use")]
 
     authentication: Annotated[bool, Doc("Require authentication")] = False

--- a/backend/src/acidwatch_api/models/co2spec.py
+++ b/backend/src/acidwatch_api/models/co2spec.py
@@ -25,6 +25,7 @@ class TocomoAdapter(BaseAdapter):
     model_id = "co2spec"
     display_name = "ToCoMo"
     description = DESCRIPTION
+    category: str = "Primary"
 
     valid_substances = [
         "O2",

--- a/backend/src/acidwatch_api/models/datamodel.py
+++ b/backend/src/acidwatch_api/models/datamodel.py
@@ -41,6 +41,7 @@ class ModelInfo(BaseModel):
     model_id: str
     display_name: str
     description: str
+    category: str
     valid_substances: list[str]
     parameters: dict[str, Any]
 

--- a/backend/src/acidwatch_api/models/gibbs_minimization_model.py
+++ b/backend/src/acidwatch_api/models/gibbs_minimization_model.py
@@ -87,6 +87,7 @@ class GibbsMinimizationModelAdapter(BaseAdapter):
     display_name = "Gibbs Minimization Model"
     parameters: GibbsMinimizationModelParameters
     description = DESCRIPTION
+    category: str = "Primary"
 
     async def run(self) -> RunResult:
         eos = self.parameters.equation_of_state

--- a/backend/src/acidwatch_api/models/solubilityccs.py
+++ b/backend/src/acidwatch_api/models/solubilityccs.py
@@ -48,6 +48,7 @@ class SolubilityCCSAdapter(BaseAdapter):
     description = DESCRIPTION
     valid_substances = ["H2O", "H2SO4", "HNO3"]
     parameters: SolubilityCCSParameters
+    category: str = "Secondary"
 
     async def run(self) -> RunResult:
         # Get concentrations (mole fractions)

--- a/backend/tests/test_models_endpoints.py
+++ b/backend/tests/test_models_endpoints.py
@@ -42,7 +42,7 @@ class DummyAdapter(base.BaseAdapter):
     model_id = "dummy"
     display_name = "Dummy Model"
     description = ""
-
+    category = "Dummy"
     valid_substances = []
 
     async def run(self):
@@ -157,6 +157,7 @@ def test_dummy_has_correct_parameter_name(client, monkeypatch, dummy_model):
             "accessError": None,
             "displayName": "Dummy Model",
             "description": "",
+            "category": "Dummy",
             "modelId": "dummy",
             "parameters": {
                 # Notice that it's "someField" and not "some_field"

--- a/frontend/src/dto/FormConfig.tsx
+++ b/frontend/src/dto/FormConfig.tsx
@@ -35,4 +35,5 @@ export interface ModelConfig {
     validSubstances: string[];
     parameters: Record<string, ParameterConfig>;
     description: string;
+    category: string;
 }


### PR DESCRIPTION
The idea is that whenever a user clicks a row, we will run a simulation per model for the results and whenever they are finished we update the plot.

Not at all complete, but it shows the concept

partially solves: #422 

Once we have the precomputed results we can swap out how we retrieve the simulations, so keeping this PR so we can implement comparison.

https://github.com/user-attachments/assets/7a2f2e40-8c07-4c56-975a-ff10ad5c5b1e

