### PR TITLE
Set arcs model default to 2000 samples

### DIFF
--- a/backend/src/acidwatch_api/models/arcs.py
+++ b/backend/src/acidwatch_api/models/arcs.py
@@ -27,13 +27,6 @@ class ArcsParameters(BaseParameters):
         max=300,
     )
 
-    samples: int = Parameter(
-        10,
-        label="Number of Samples",
-        min=1,
-        max=1000,
-    )
-
 
 class ArcsAdapter(BaseAdapter):
     model_id = "arcs"
@@ -77,7 +70,7 @@ class ArcsAdapter(BaseAdapter):
                 },
                 "temperature": self.parameters.temperature,
                 "pressure": self.parameters.pressure,
-                "samples": self.parameters.samples,
+                "samples": 2000,  # Default to 2000 samples
             },
             timeout=300.0,
         )


### PR DESCRIPTION
Runs with merely 10 samples will be completely random each time, it
isn't worth anything to do that. To be very safe one should run in the
order of 5000. After some testing we figure 2000 should give reasonable
estimates.

solves: https://github.com/equinor/acidwatch/issues/149
