### PR TITLE
Use dashes to signify zeroes in the conc table

### DIFF
--- a/frontend/src/components/ConcResultTable.tsx
+++ b/frontend/src/components/ConcResultTable.tsx
@@ -16,16 +16,20 @@ const ResultConcTable: React.FC<ResultConcTableProps> = ({ initialConcentrations
                 </Table.Row>
             </Table.Head>
             <Table.Body>
-                {Object.keys(finalConcentrations).map((key, index) => (
-                    <Table.Row key={index}>
-                        <Table.Cell>{key}</Table.Cell>
-                        <Table.Cell>{(initialConcentrations[key] ?? 0).toFixed(3)}</Table.Cell>
-                        <Table.Cell>{finalConcentrations[key].toFixed(3)}</Table.Cell>
-                        <Table.Cell>
-                            {(finalConcentrations[key] - (initialConcentrations[key] ?? 0)).toFixed(3)}
-                        </Table.Cell>
-                    </Table.Row>
-                ))}
+                {Object.keys(finalConcentrations).map((key, index) => {
+                    const init = initialConcentrations[key] ?? 0;
+                    const final = finalConcentrations[key] ?? 0;
+                    const change = final - init;
+
+                    return (
+                        <Table.Row key={index}>
+                            <Table.Cell>{key}</Table.Cell>
+                            <Table.Cell>{init >= 0.001 ? init.toFixed(3) : "-"}</Table.Cell>
+                            <Table.Cell>{final >= 0.001 ? final.toFixed(3) : "-"}</Table.Cell>
+                            <Table.Cell>{Math.abs(change) >= 0.001 ? change.toFixed(3) : "-"}</Table.Cell>
+                        </Table.Row>
+                    );
+                })}
             </Table.Body>
         </Table>
     );


### PR DESCRIPTION
Makes it a tad bit more readable. The value needs to be exactly zero, hence the `0.000` which seems out of place, but that means that it's just a small non-zero quantity.

<img width="718" height="454" alt="image" src="https://github.com/user-attachments/assets/dbe2ff8b-08cb-4871-9128-b574ceff1711" />
