### PR TITLE
Include input details in result page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,10 +5,10 @@ import TopBar from "./components/TopBar";
 import SideBar from "./components/SideBar";
 import Dashboard from "./pages/Home";
 import SimulationList from "./pages/SimulationList";
-import Results from "./pages/Results";
 import ErrorDialog from "./components/ErrorDialog";
 import LabResults from "./pages/LabResults";
 import HelpPage from "./pages/HelpPage";
+import SimulationResult from "./pages/SimulationResult";
 import DynamicBreadcrumbs from "./components/DynamicBreadcrumbs";
 import Models from "./pages/Models";
 import { AvailableModelsProvider } from "./contexts/ModelContext";
@@ -55,7 +55,7 @@ const routes: Record<string, React.FC> = {
     "/": Dashboard,
     "/project/:projectId": SimulationList,
     "/project/:projectId/input": Models,
-    "/project/:projectId/simulation/:simulationId": Results,
+    "/project/:projectId/simulation/:simulationId": SimulationResult,
     "/models": Models,
     "/labresults": LabResults,
     "/help": HelpPage,

--- a/frontend/src/api/api.tsx
+++ b/frontend/src/api/api.tsx
@@ -128,6 +128,22 @@ export const deleteProject = async (projectId: string) => {
         console.error("Error deleting project:", error);
     }
 };
+export const getSimulation = async (projectId: string, scenarioId: string): Promise<Simulation | null> => {
+    const token = await getAccessToken();
+    const response = await fetch(config.API_URL + "/project/" + projectId + "/scenario/" + scenarioId, {
+        method: "GET",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer " + token,
+        },
+    });
+
+    if (!response.ok) {
+        throw new Error("Network response was not ok");
+    }
+    const data: Simulation = await response.json();
+    return data;
+};
 
 export const getSimulations = async (projectId: string): Promise<Simulation[]> => {
     const token = await getAccessToken();

--- a/frontend/src/dto/Simulation.tsx
+++ b/frontend/src/dto/Simulation.tsx
@@ -1,10 +1,11 @@
 export interface Simulation {
+    model: string;
     id: number;
     name: string;
     owner: string;
-    scenario_inputs: {
-        concs: { [key: string]: number };
-        settings: { [key: string]: number };
+    scenarioInputs: {
+        initialConcentrations: { [key: string]: number };
+        parameters: { [key: string]: number };
     };
     date: string;
 }

--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -63,7 +63,7 @@ const Results: React.FC<ResultsProps> = ({ simulationResults }) => {
     if (!simulationResults && fetchedResults != null) simulationResults = fetchedResults;
 
     if (!simulationResults) return <Typography color="red">No simulation results found</Typography>;
-    console.log(simulationResults);
+
     const hasConcentrations = Object.keys(simulationResults.finalConcentrations).length > 0;
 
     return (

--- a/frontend/src/pages/SimulationResult.tsx
+++ b/frontend/src/pages/SimulationResult.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from "react";
+import React from "react";
+
+import { Typography, Card, CardContent } from "@equinor/eds-core-react";
+import { getSimulation, getSimulationResults } from "../api/api";
+import { useParams } from "react-router-dom";
+import styled from "styled-components";
+import { tokens } from "@equinor/eds-tokens";
+import Results from "./Results";
+import { useQuery } from "@tanstack/react-query";
+import { SimulationResults } from "../dto/SimulationResults";
+
+const StyledRow = styled.div`
+    display: grid;
+    grid-template-columns: 1fr 91px;
+    gap: 8px;
+`;
+
+const SimulationResult: React.FC = () => {
+    const { projectId, simulationId } = useParams<{ projectId: string; simulationId: string }>();
+    const [concentrations, setConcentrations] = useState<Record<string, number>>({});
+    const [parameters, setParameters] = useState<Record<string, number>>({});
+    const [simulationName, setSimulationName] = useState<string | undefined>(undefined);
+    const [model, setModel] = useState<string | undefined>(undefined);
+
+    const { data: fetchedResults } = useQuery<SimulationResults | null>({
+        queryKey: [`get-simulation-${projectId}-${simulationId}`],
+        queryFn: () => getSimulationResults(projectId!, simulationId!),
+        enabled: !!projectId && !!simulationId,
+    });
+
+    useEffect(() => {
+        const fetchSimulation = async () => {
+            if (!projectId || !simulationId) return;
+            try {
+                const simulation = await getSimulation(projectId, simulationId);
+
+                if (simulation) {
+                    setSimulationName(simulation.name);
+                    setModel(simulation.model);
+                    setConcentrations(simulation.scenarioInputs.initialConcentrations || {});
+                    setParameters(simulation.scenarioInputs.parameters || {});
+                }
+            } catch (error) {
+                console.error("Error fetching simulation:", error);
+            }
+        };
+
+        fetchSimulation();
+    }, [projectId, simulationId]);
+
+    const renderKeyValuePairs = (data: Record<string, number>) => {
+        return Object.entries(data)
+            .filter(([, value]) => value !== 0)
+            .map(([key, value]) => (
+                <StyledRow key={key}>
+                    <Typography>{key}:</Typography>
+                    <Typography>{value}</Typography>
+                </StyledRow>
+            ));
+    };
+
+    return (
+        <div style={{ display: "flex" }}>
+            <div style={{ marginLeft: "15px" }}>
+                <Card
+                    elevation="raised"
+                    style={{
+                        padding: "8px",
+                        width: "300px",
+                        backgroundColor: tokens.colors.infographic.primary__moss_green_13.hex,
+                    }}
+                >
+                    <CardContent>
+                        <StyledRow>
+                            <Typography>Simulation name</Typography>
+                            <Typography>{simulationName}</Typography>
+                        </StyledRow>
+                        <StyledRow>
+                            <Typography>Model</Typography>
+                            <Typography>{model}</Typography>
+                        </StyledRow>
+                        <br />
+                        <StyledRow>
+                            <Typography
+                                token={{
+                                    textDecoration: "underline",
+                                }}
+                            >
+                                Initial concentrations
+                            </Typography>
+                        </StyledRow>
+
+                        {renderKeyValuePairs(concentrations)}
+                        <br />
+                        <StyledRow>
+                            <Typography
+                                token={{
+                                    textDecoration: "underline",
+                                }}
+                            >
+                                Parameters
+                            </Typography>
+                        </StyledRow>
+                        {renderKeyValuePairs(parameters)}
+                    </CardContent>
+                </Card>
+            </div>
+            <div style={{ marginLeft: "50px" }}>
+                <Results simulationResults={fetchedResults ?? undefined} />
+            </div>
+        </div>
+    );
+};
+
+export default SimulationResult;


### PR DESCRIPTION
Previously, when clicking a simulation in the list, you where sent to result page without any info on settings used for the simulation. This adds a card with relevent info:

<img width="953" height="579" alt="image" src="https://github.com/user-attachments/assets/e155da45-bba0-40ad-b231-5003bfa6d5ff" />