### PR TITLE
Increase radix node requirements

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -85,7 +85,7 @@ spec:
           resources:
               requests:
                   memory: "800M"
-                  cpu: "100m"
+                  cpu: "4000m"
               limits:
                   memory: "800M"
-                  cpu: "100m"
+                  cpu: "4000m"


### PR DESCRIPTION
The unit `m` stands for millicores, so 100m equals 0.1 CPU. I think we
can safely increase.

:D
