### PR TITLE
Change useQuery defaults to avoid refetching

### DIFF
--- a/frontend/src/contexts/SimulationContext.tsx
+++ b/frontend/src/contexts/SimulationContext.tsx
@@ -20,6 +20,7 @@ export const SimulationResultsProvider: React.FC<{ children: ReactNode }> = ({ c
         queryKey: ["startSimluation", modelInput],
         queryFn: async () => startSimulation(modelInput!),
         enabled: modelInput !== undefined,
+        gcTime: Infinity,
     });
 
     const { data: simulationResults, isLoading } = useQuery({

--- a/frontend/src/hooks/useSimulationQueriesResult.ts
+++ b/frontend/src/hooks/useSimulationQueriesResult.ts
@@ -48,11 +48,7 @@ export const useSimulationQueries = (experiments: ExperimentResult[]): UseSimula
                     experiment: experiment,
                 }),
                 retryOnMount: false,
-                staleTime: "static",
                 gcTime: Infinity,
-                refetchOnMount: false,
-                refetchOnWindowFocus: false,
-                refetchOnReconnect: false,
             };
         }),
         combine: (queryResults) => queryResults.filter((value) => value.isSuccess).map((value) => value.data),
@@ -66,10 +62,6 @@ export const useSimulationQueries = (experiments: ExperimentResult[]): UseSimula
                 result: await getResultForSimulation(simulationId.result),
             }),
             retry: (_failureCount: number, error: Error): boolean => error instanceof ResultIsPending,
-            retryOnMount: false,
-            refetchOnMount: false,
-            refetchOnWindowFocus: false,
-            refetchOnReconnect: false,
         })),
         combine: (queryResults) => {
             const data: Record<string, SimulationResults[]> = {};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,6 +9,13 @@ import { MsalProvider } from "@azure/msal-react";
 import { msalInstance } from "./services/auth";
 
 const queryClient = new QueryClient();
+queryClient.setDefaultOptions({
+    queries: {
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+        staleTime: "static",
+    },
+});
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>


### PR DESCRIPTION
useQuery refetches on eg. window change. So if you click away from the tab and then click on the AcidWatch tab, then AcidWatch will refetch eg. the models, or at worst, restart the simulation. Very silly!