### PR TITLE
Validate in frontend using zod

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,6 +29,7 @@
                 "styled-components": "^6.1.19",
                 "typescript": "^5.9",
                 "vite": "^7.1.9",
+                "zod": "^4.1.12",
                 "zustand": "^5.0.0"
             },
             "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
         "styled-components": "^6.1.19",
         "typescript": "^5.9",
         "vite": "^7.1.9",
+        "zod": "^4.1.12",
         "zustand": "^5.0.0"
     },
     "resolutions": {

--- a/frontend/src/components/SaveResult.tsx
+++ b/frontend/src/components/SaveResult.tsx
@@ -12,7 +12,7 @@ import SaveButton from "./SaveButton";
 import CreateProjectPrompt from "./CreateProjectPrompt";
 
 interface SimulationProps {
-    parameters: Record<string, number>;
+    parameters: Record<string, number | string>;
     selectedModel: string;
     result: SimulationResults | undefined;
 }

--- a/frontend/src/dto/ExperimentResult.tsx
+++ b/frontend/src/dto/ExperimentResult.tsx
@@ -1,8 +1,11 @@
-export interface ExperimentResult {
-    name: string; // CDC-049-A
-    initialConcentrations: Record<string, number>;
-    finalConcentrations: Record<string, number>;
-    pressure: number | null;
-    temperature: number | null;
-    time: number | null; // Elapsed experiment time in hours
-}
+import * as z from "zod";
+
+export const ExperimentResult = z.object({
+    name: z.string(), // CDC-049-A
+    initialConcentrations: z.record(z.string(), z.number()),
+    finalConcentrations: z.record(z.string(), z.number()),
+    pressure: z.nullable(z.number()),
+    temperature: z.nullable(z.number()),
+    time: z.nullable(z.number()), // elapsed experiment time in hours
+});
+export type ExperimentResult = z.infer<typeof ExperimentResult>;

--- a/frontend/src/dto/FormConfig.tsx
+++ b/frontend/src/dto/FormConfig.tsx
@@ -1,21 +1,24 @@
-interface ParameterConfig {
-    default: number;
-    label?: string;
-    description?: string;
-    unit?: string;
-    convertibleUnit?: string;
-    minimum?: number;
-    maximum?: number;
-    choices?: string[];
-    optionLabels?: string[];
-}
+import * as z from "zod";
 
-export interface ModelConfig {
-    accessError?: string;
-    modelId: string;
-    displayName: string;
-    validSubstances: string[];
-    parameters: Record<string, ParameterConfig>;
-    description: string;
-    category: string;
-}
+const ParameterConfig = z.object({
+    default: z.union([z.string(), z.number()]),
+    label: z.optional(z.string()),
+    description: z.optional(z.string()),
+    unit: z.optional(z.string()),
+    convertibleUnit: z.optional(z.string()),
+    minimum: z.optional(z.number()),
+    maximum: z.optional(z.number()),
+    choices: z.optional(z.array(z.string())),
+    optionLabels: z.optional(z.array(z.string())),
+});
+
+export const ModelConfig = z.object({
+    accessError: z.nullable(z.string()),
+    modelId: z.string(),
+    displayName: z.string(),
+    validSubstances: z.array(z.string()),
+    parameters: z.record(z.string(), ParameterConfig),
+    description: z.string(),
+    category: z.string(),
+});
+export type ModelConfig = z.infer<typeof ModelConfig>;

--- a/frontend/src/dto/ModelInput.tsx
+++ b/frontend/src/dto/ModelInput.tsx
@@ -1,5 +1,9 @@
-﻿export interface ModelInput {
-    concentrations: Record<string, number>;
-    parameters: Record<string, number>;
-    modelId: string;
-}
+﻿import * as z from "zod";
+
+export const ModelInput = z.object({
+    concentrations: z.record(z.string(), z.number()),
+    parameters: z.record(z.string(), z.union([z.number(), z.string()])),
+    modelId: z.string(),
+});
+
+export type ModelInput = z.infer<typeof ModelInput>;

--- a/frontend/src/dto/Project.tsx
+++ b/frontend/src/dto/Project.tsx
@@ -1,10 +1,14 @@
-export interface Project {
-    id: string;
-    name: string;
-    description: string;
-    owner: string;
-    owner_id: string;
-    private: boolean;
-    access_ids: string[];
-    date: string;
-}
+import * as z from "zod";
+
+export const Project = z.object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string(),
+    owner: z.string(),
+    owner_id: z.string(),
+    private: z.boolean(),
+    access_ids: z.array(z.string()),
+    date: z.date(),
+});
+
+export type Project = z.infer<typeof Project>;

--- a/frontend/src/dto/Simulation.tsx
+++ b/frontend/src/dto/Simulation.tsx
@@ -1,11 +1,15 @@
-export interface Simulation {
-    model: string;
-    id: number;
-    name: string;
-    owner: string;
-    scenarioInputs: {
-        initialConcentrations: { [key: string]: number };
-        parameters: { [key: string]: number };
-    };
-    date: string;
-}
+import * as z from "zod";
+
+export const Simulation = z.object({
+    model: z.string(),
+    id: z.number(),
+    name: z.string(),
+    owner: z.string(),
+    scenarioInputs: z.object({
+        initialConcentrations: z.record(z.string(), z.number()),
+        parameters: z.record(z.string(), z.number()),
+    }),
+    date: z.date(),
+});
+
+export type Simulation = z.infer<typeof Simulation>;

--- a/frontend/src/dto/SimulationResults.tsx
+++ b/frontend/src/dto/SimulationResults.tsx
@@ -1,34 +1,38 @@
+import * as z from "zod";
 import { ModelInput } from "./ModelInput";
 
-interface TextPanel {
-    type: "text";
-    label?: string;
-    data: string;
-}
+const TextPanel = z.object({
+    type: z.literal("text"),
+    label: z.optional(z.string()),
+    data: z.string(),
+});
 
-interface JsonPanel {
-    type: "json";
-    label?: string;
-    data: any;
-}
+const JsonPanel = z.object({
+    type: z.literal("json"),
+    label: z.optional(z.string()),
+    data: z.any(),
+});
 
-interface ReactionPathsPanel {
-    type: "reaction_paths";
-    label?: string;
-    common_paths: any;
-    stats: any;
-}
+const ReactionPathsPanel = z.object({
+    type: z.literal("reaction_paths"),
+    label: z.optional(z.string()),
+    common_paths: z.any(),
+    stats: z.any(),
+});
 
-interface TablePanel {
-    type: "table";
-    label?: string;
-    data: Record<string, any>[];
-}
+const TablePanel = z.object({
+    type: z.literal("table"),
+    label: z.optional(z.string()),
+    data: z.array(z.record(z.string(), z.union([z.string(), z.number()]))),
+});
 
-export type Panel = TextPanel | JsonPanel | ReactionPathsPanel | TablePanel;
-export interface SimulationResults {
-    status: "done" | "pending";
-    modelInput: ModelInput;
-    finalConcentrations: { [key: string]: number };
-    panels: Panel[];
-}
+export const Panel = z.discriminatedUnion("type", [TextPanel, JsonPanel, ReactionPathsPanel, TablePanel]);
+export type Panel = z.infer<typeof Panel>;
+
+export const SimulationResults = z.object({
+    status: z.enum(["done", "pending"]),
+    modelInput: ModelInput,
+    finalConcentrations: z.record(z.string(), z.number()),
+    panels: z.array(Panel),
+});
+export type SimulationResults = z.infer<typeof SimulationResults>;

--- a/frontend/src/functions/Formatting.tsx
+++ b/frontend/src/functions/Formatting.tsx
@@ -45,14 +45,10 @@ export const extractPlotData = (simulationResults: SimulationResults) => {
     ];
 };
 
-export const ISODate_to_UIDate = (ISODate: string) => {
-    const date = new Date(ISODate);
+export const ISODate_to_UIDate = (date: Date) => {
     const day = date.getDate();
     const month = date.toLocaleString("default", { month: "short" });
     const year = date.getFullYear();
-    if (isNaN(day) || month.length !== 3 || isNaN(year)) {
-        return ISODate;
-    }
     return `${day}. ${month} ${year}`;
 };
 
@@ -67,7 +63,7 @@ const buildTabulatedRow = (
     label: string,
     inputsConcentrations: Record<string, number>,
     finalConcentration: Record<string, number>,
-    parameters: Record<string, number>
+    parameters: Record<string, number | string>
 ): TabulatedResultRow => {
     const row: TabulatedResultRow = {};
 
@@ -100,7 +96,7 @@ export const convertSimulationQueriesResultToTabulatedData = (
                     `${simulation.modelInput.modelId || "Unknown"} - ${experimentName}`,
                     simulation.modelInput.concentrations,
                     simulation.finalConcentrations,
-                    simulation.modelInput.parameters ?? {}
+                    simulation.modelInput.parameters
                 )
             );
         });


### PR DESCRIPTION
This commit adds zod and replaces dto with zod-based schema. To make this change easier, `apiRequest` now has a `responseModel` "kwarg" which is a zod schema and is validated. Errors are logged. Additionally, it's now not possible to directly obtain a JSON from `apiRequest` unless you go via `responseReturn: true` which gives a raw `Response` instance.