### PR TITLE
Remove model adapter auto-registration

### DIFF
--- a/backend/src/acidwatch_api/models/__init__.py
+++ b/backend/src/acidwatch_api/models/__init__.py
@@ -1,4 +1,17 @@
-from . import tocomo, arcs, solubilityccs, gibbs_minimization_model, phpitz
+from .base import BaseAdapter, InputError, get_parameters_schema
+from .tocomo import TocomoAdapter
+from .arcs import ArcsAdapter
+from .solubilityccs import SolubilityCCSAdapter
+from .gibbs_minimization_model import GibbsMinimizationModelAdapter
+from .phpitz import PhpitzAdapter
 
-
-__all__ = ["arcs", "tocomo", "solubilityccs", "gibbs_minimization_model", "phpitz"]
+__all__ = [
+    "BaseAdapter",
+    "InputError",
+    "get_parameters_schema",
+    "TocomoAdapter",
+    "ArcsAdapter",
+    "SolubilityCCSAdapter",
+    "GibbsMinimizationModelAdapter",
+    "PhpitzAdapter",
+]

--- a/backend/src/acidwatch_api/models/base.py
+++ b/backend/src/acidwatch_api/models/base.py
@@ -31,19 +31,11 @@ from pydantic import (
     ValidationError,
     ValidationInfo,
 )
-import inspect
-
-
-ADAPTERS: dict[str, type[BaseAdapter]] = {}
 
 
 class InputError(ValueError):
     def __init__(self, detail: dict[str, Any]) -> None:
         self.detail = detail
-
-
-def get_adapters() -> dict[str, type[BaseAdapter]]:
-    return ADAPTERS
 
 
 Compound: TypeAlias = str
@@ -263,14 +255,6 @@ class BaseAdapter:
                 raise TypeError(
                     f"{cls} declares field 'parameters', but it's not a subclass of BaseParameters"
                 )
-
-        # Automatically register adapter
-        if (other_cls := ADAPTERS.get(cls.model_id)) is not None:
-            raise ValueError(
-                f"Model adapter with ID '{cls.model_id}' has already been declared in {inspect.getfile(other_cls)}"
-            )
-
-        ADAPTERS[cls.model_id] = cls
 
     model_id: Annotated[str, Doc("Unique model identifier")]
 

--- a/backend/tests/models/test_adapter.py
+++ b/backend/tests/models/test_adapter.py
@@ -4,24 +4,6 @@ import pytest
 from acidwatch_api.models import base
 
 
-@pytest.fixture(autouse=True)
-def no_adapters(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(base, "ADAPTERS", {})
-
-
-def test_subclass_is_automatically_registered():
-    # We have no pre-registered adapters
-    assert base.ADAPTERS == {}
-
-    class DummyAdapter(base.BaseAdapter):
-        model_id = "dummy"
-
-    # "dummy" is the only registered adapter
-    assert len(base.ADAPTERS) == 1
-    assert base.ADAPTERS["dummy"] is DummyAdapter
-    assert base._get_parameters_type(DummyAdapter) is None
-
-
 def test_parameters_class_must_contain_only_parameter_fields():
     # Pydantic handles this one
     with pytest.raises(TypeError, match="All model fields require a type annotation"):

--- a/backend/tests/models/test_all_adapters.py
+++ b/backend/tests/models/test_all_adapters.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 import pytest
 import re
-from acidwatch_api.models.base import ADAPTERS, BaseAdapter
+from acidwatch_api.models import BaseAdapter
+from acidwatch_api.routes.models import get_adapters
 
 
 ATOM_PATTERN = (
@@ -98,12 +99,12 @@ def test_sanity_check_bad(substance):
         _assert_is_valid_substance(substance)
 
 
-@pytest.mark.parametrize("adapter", ADAPTERS.values())
+@pytest.mark.parametrize("adapter", get_adapters().values())
 def test_has_model_name(adapter: BaseAdapter):
     assert adapter.display_name.strip() != ""
 
 
-@pytest.mark.parametrize("adapter", ADAPTERS.values())
+@pytest.mark.parametrize("adapter", get_adapters().values())
 def test_init_concs(adapter: BaseAdapter):
     for substance in adapter.valid_substances:
         assert substance != "CO2", (

--- a/backend/tests/test_models_endpoints.py
+++ b/backend/tests/test_models_endpoints.py
@@ -1,5 +1,6 @@
 from enum import StrEnum
 
+from acidwatch_api.routes.models import get_adapters
 import pytest
 from fastapi.testclient import TestClient as _BaseTestClient
 from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
@@ -36,7 +37,7 @@ def client(monkeypatch):
 def test_get_models(client):
     response = client.get("/models")
     assert response.status_code == 200
-    assert len(response.json()) == 6
+    assert len(response.json()) == 5
 
 
 class DummyAdapter(base.BaseAdapter):
@@ -51,8 +52,10 @@ class DummyAdapter(base.BaseAdapter):
 
 
 @pytest.fixture
-def dummy_model(monkeypatch):
-    monkeypatch.setattr(base, "ADAPTERS", {DummyAdapter.model_id: DummyAdapter})
+def dummy_model(client):
+    client.app.dependency_overrides[get_adapters] = lambda: {
+        DummyAdapter.model_id: DummyAdapter
+    }
     return DummyAdapter
 
 


### PR DESCRIPTION
Instead of automatically registering models where they are defined, we instead explicitly enumerate all the models in a FastAPI dependency, which can be overridden better in tests. In the future we may have a plugin system, but the FastAPI dependency overriding may yet remain.