### PR TITLE
Separate temperature and pressure from model parameters (#636)

### DIFF
--- a/backend/alembic/versions/7c2e9a4b1f3d_separate_conditions.py
+++ b/backend/alembic/versions/7c2e9a4b1f3d_separate_conditions.py
@@ -1,0 +1,97 @@
+"""separate conditions (temperature, pressure) on simulations
+
+Revision ID: 7c2e9a4b1f3d
+Revises: 01aaa143d690
+Create Date: 2026-04-30 06:45:00.000000
+
+Lifts `temperature` and `pressure` out of every model_input's `parameters`
+JSON blob and stores them as first-class columns on `simulations`. See
+issue equinor/acidwatch#636 — conditions describe the system (alongside
+concentrations), not individual model tuning.
+
+Strategy:
+  1. Add nullable `temperature`/`pressure` columns to `simulations`.
+  2. Copy values from the first model_input per simulation that has them
+     (they were always meant to be the same across the chain).
+  3. Strip `temperature`/`pressure` keys from every model_input's
+     `parameters` JSON.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "7c2e9a4b1f3d"
+down_revision: Union[str, Sequence[str], None] = "01aaa143d690"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "simulations",
+        sa.Column("temperature", sa.Float(), nullable=True),
+    )
+    op.add_column(
+        "simulations",
+        sa.Column("pressure", sa.Float(), nullable=True),
+    )
+
+    # Lift temperature/pressure from any model_input that has them. Across a
+    # simulation's chain these values were always meant to be identical, so
+    # picking the lowest created_at is safe. Columns are `json` (not jsonb)
+    # so we cast to jsonb for key-existence and key-removal operators.
+    op.execute("""
+        UPDATE simulations s
+        SET temperature = (
+            SELECT (mi.parameters::jsonb->>'temperature')::float
+            FROM model_inputs mi
+            WHERE mi.simulation_id = s.id
+              AND mi.parameters::jsonb ? 'temperature'
+            ORDER BY mi.created_at ASC
+            LIMIT 1
+        )
+    """)
+    op.execute("""
+        UPDATE simulations s
+        SET pressure = (
+            SELECT (mi.parameters::jsonb->>'pressure')::float
+            FROM model_inputs mi
+            WHERE mi.simulation_id = s.id
+              AND mi.parameters::jsonb ? 'pressure'
+            ORDER BY mi.created_at ASC
+            LIMIT 1
+        )
+    """)
+
+    # Strip the lifted keys out of each model_input's parameters JSON.
+    op.execute("""
+        UPDATE model_inputs
+        SET parameters = ((parameters::jsonb) - 'temperature' - 'pressure')::json
+        WHERE parameters::jsonb ? 'temperature'
+           OR parameters::jsonb ? 'pressure'
+    """)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Best-effort restore: write the simulation's temperature/pressure back
+    # into every model_input's parameters JSON, then drop the columns.
+    op.execute("""
+        UPDATE model_inputs mi
+        SET parameters = (
+            (mi.parameters::jsonb)
+            || jsonb_build_object('temperature', s.temperature)
+            || jsonb_build_object('pressure', s.pressure)
+        )::json
+        FROM simulations s
+        WHERE mi.simulation_id = s.id
+          AND s.temperature IS NOT NULL
+          AND s.pressure IS NOT NULL
+    """)
+    op.drop_column("simulations", "pressure")
+    op.drop_column("simulations", "temperature")

--- a/backend/src/acidwatch_api/database.py
+++ b/backend/src/acidwatch_api/database.py
@@ -8,6 +8,7 @@ from uuid import UUID, uuid4
 from fastapi import Depends, FastAPI, Request
 from sqlalchemy import (
     Engine,
+    Float,
     ForeignKey,
     DateTime,
     PickleType,
@@ -45,6 +46,8 @@ class Simulation(Base):
 
     owner_id: Mapped[UUID | None] = mapped_column(Uuid)
     concentrations: Mapped[dict[str, float]] = mapped_column(JSON)
+    temperature: Mapped[float | None] = mapped_column(Float, nullable=True)
+    pressure: Mapped[float | None] = mapped_column(Float, nullable=True)
 
     model_inputs: Mapped[list[ModelInput]] = relationship(back_populates="simulation")
 

--- a/backend/src/acidwatch_api/models/arcs.py
+++ b/backend/src/acidwatch_api/models/arcs.py
@@ -3,9 +3,7 @@ from acidwatch_api.models.datamodel import ReactionPathsResult
 from acidwatch_api.models.base import (
     BaseAdapter,
     BaseParameters,
-    Parameter,
     RunResult,
-    Unit,
 )
 from acidwatch_api.settings import SETTINGS
 
@@ -18,23 +16,7 @@ DESCRIPTION: str = """Automated Reactions for CO2 Storage (ARCS) model.
 
 
 class ArcsParameters(BaseParameters):
-    temperature: int = Parameter(
-        300,
-        label="Temperature",
-        unit=Unit.TEMPERATURE_KELVIN,
-        min=200,
-        max=400,
-        description="Temperature in Celsius",
-    )
-
-    pressure: int = Parameter(
-        10,
-        label="Pressure",
-        unit="bara",
-        min=1,
-        max=300,
-        description="Pressure in bara",
-    )
+    pass
 
 
 class ArcsAdapter(BaseAdapter):
@@ -71,6 +53,8 @@ class ArcsAdapter(BaseAdapter):
 
     parameters: ArcsParameters
     base_url = SETTINGS.arcs_api_base_uri
+    temperature_range = (200.0, 400.0)
+    pressure_range = (1.0, 300.0)
 
     async def run(self) -> RunResult:
         response = await self.client.post(
@@ -79,8 +63,8 @@ class ArcsAdapter(BaseAdapter):
                 "concs": {
                     key: value / 1e6 for key, value in self.concentrations.items()
                 },
-                "temperature": self.parameters.temperature,
-                "pressure": self.parameters.pressure,
+                "temperature": self.temperature,
+                "pressure": self.pressure,
                 "samples": 2000,  # Default to 2000 samples
             },
             timeout=300.0,

--- a/backend/src/acidwatch_api/models/arcs_exp.py
+++ b/backend/src/acidwatch_api/models/arcs_exp.py
@@ -1,9 +1,7 @@
 from acidwatch_api.models.base import (
     BaseAdapter,
     BaseParameters,
-    Parameter,
     RunResult,
-    Unit,
 )
 from acidwatch_api.settings import SETTINGS
 
@@ -17,23 +15,7 @@ DESCRIPTION: str = """Automated Reactions for CO2 Storage (ARCS) model.
 
 
 class ArcsParameters(BaseParameters):
-    temperature: int = Parameter(
-        300,
-        label="Temperature",
-        unit=Unit.TEMPERATURE_KELVIN,
-        min=200,
-        max=400,
-        description="Temperature in Celsius",
-    )
-
-    pressure: int = Parameter(
-        10,
-        label="Pressure",
-        unit="bara",
-        min=1,
-        max=300,
-        description="Pressure in bara",
-    )
+    pass
 
 
 class ArcsExpAdapter(BaseAdapter):
@@ -70,6 +52,8 @@ class ArcsExpAdapter(BaseAdapter):
 
     parameters: ArcsParameters
     base_url = SETTINGS.arcs_exp_api_base_uri
+    temperature_range = (200.0, 400.0)
+    pressure_range = (1.0, 300.0)
 
     async def run(self) -> RunResult:
         response = await self.client.post(
@@ -78,8 +62,8 @@ class ArcsExpAdapter(BaseAdapter):
                 "concs": {
                     key: value / 1e6 for key, value in self.concentrations.items()
                 },
-                "temperature": self.parameters.temperature,
-                "pressure": self.parameters.pressure,
+                "temperature": self.temperature,
+                "pressure": self.pressure,
                 "samples": 500,
             },
             timeout=300.0,

--- a/backend/src/acidwatch_api/models/base.py
+++ b/backend/src/acidwatch_api/models/base.py
@@ -195,8 +195,39 @@ class BaseAdapter:
         *,
         concentrations: dict[str, int | float] | None = None,
         parameters: dict[str, str | bool | int | float] | None,
+        temperature: float | None = None,
+        pressure: float | None = None,
         jwt_token: str | None,
     ) -> None:
+        condition_errors: dict[str, list[str]] = {}
+        temperature_range = type(self).temperature_range
+        if temperature_range is not None:
+            if temperature is None:
+                condition_errors["temperature"] = ["Field required"]
+            elif not (temperature_range[0] <= temperature <= temperature_range[1]):
+                condition_errors["temperature"] = [
+                    f"Input must be between {temperature_range[0]} and {temperature_range[1]}"
+                ]
+        pressure_range = type(self).pressure_range
+        if pressure_range is not None:
+            if pressure is None:
+                condition_errors["pressure"] = ["Field required"]
+            elif not (pressure_range[0] <= pressure <= pressure_range[1]):
+                condition_errors["pressure"] = [
+                    f"Input must be between {pressure_range[0]} and {pressure_range[1]}"
+                ]
+        if condition_errors:
+            raise InputError(
+                {
+                    "concentrations": {},
+                    "parameters": {},
+                    "conditions": condition_errors,
+                }
+            )
+
+        self.temperature = temperature
+        self.pressure = pressure
+
         if concentrations is not None:
             self.validate_concentrations(concentrations)
             self.set_concentrations(concentrations)
@@ -273,6 +304,22 @@ class BaseAdapter:
     )
 
     base_url: Annotated[str | None, Doc("BaseURL for accessing a remote model")] = None
+
+    temperature_range: Annotated[
+        tuple[float, float] | None,
+        Doc(
+            "Inclusive (min, max) of allowed simulation temperatures, in Kelvin. "
+            "None means this adapter does not consume temperature."
+        ),
+    ] = None
+
+    pressure_range: Annotated[
+        tuple[float, float] | None,
+        Doc(
+            "Inclusive (min, max) of allowed simulation pressures, in bara. "
+            "None means this adapter does not consume pressure."
+        ),
+    ] = None
 
     @property
     def client(self) -> httpx.AsyncClient:

--- a/backend/src/acidwatch_api/models/datamodel.py
+++ b/backend/src/acidwatch_api/models/datamodel.py
@@ -21,6 +21,8 @@ class ModelInput(_BaseModel):
 
 class Simulation(_BaseModel):
     concentrations: dict[str, int | float]
+    temperature: float | None = None
+    pressure: float | None = None
     models: list[ModelInput] = Field(min_length=1)
 
 
@@ -77,6 +79,8 @@ class ModelInfo(BaseModel):
     category: str
     valid_substances: list[str]
     parameters: dict[str, Any]
+    temperature_range: tuple[float, float] | None = None
+    pressure_range: tuple[float, float] | None = None
 
 
 class CommonPaths(BaseModel):

--- a/backend/src/acidwatch_api/models/gibbs_minimization_model.py
+++ b/backend/src/acidwatch_api/models/gibbs_minimization_model.py
@@ -90,20 +90,6 @@ class _EquationOfState(StrEnum):
 
 
 class GibbsMinimizationModelParameters(BaseParameters):
-    temperature: int = Parameter(
-        298,
-        label="Temperature",
-        unit=Unit.TEMPERATURE_KELVIN,
-        min=200,
-        max=450,
-    )
-    pressure: int = Parameter(
-        100,
-        label="Pressure",
-        unit="bara",
-        min=1,
-        max=300,
-    )
     equation_of_state: _EquationOfState = Parameter(
         _EquationOfState.SRK,
         label="Equation of State",
@@ -156,12 +142,14 @@ class GibbsMinimizationModelAdapter(BaseAdapter):
     parameters: GibbsMinimizationModelParameters
     description = DESCRIPTION
     category = "Primary"
+    temperature_range = (200.0, 450.0)
+    pressure_range = (1.0, 300.0)
 
     async def run(self) -> RunResult:
         eos = self.parameters.equation_of_state
-        temp = self.parameters.temperature
-        pres = self.parameters.pressure
-
+        temp = self.temperature
+        pres = self.pressure
+         
         if eos == _EquationOfState.SRK:
             system = jneqsim.thermo.system.SystemSrkEos(temp, pres)
         elif eos == _EquationOfState.PR:
@@ -191,8 +179,8 @@ class GibbsMinimizationModelAdapter(BaseAdapter):
 
         # # Create an inlet stream
         inlet_stream = jneqsim.process.equipment.stream.Stream("Inlet Stream", system)
-        inlet_stream.setPressure(self.parameters.pressure, "bara")
-        inlet_stream.setTemperature(self.parameters.temperature, "K")
+        inlet_stream.setPressure(pres, "bara")
+        inlet_stream.setTemperature(temp, "K")
         inlet_stream.run()
 
         # Create a Gibbs reactor

--- a/backend/src/acidwatch_api/models/phpitz.py
+++ b/backend/src/acidwatch_api/models/phpitz.py
@@ -4,29 +4,13 @@ from acidwatch_api.models.base import (
     BaseAdapter,
     BaseParameters,
     RunResult,
-    Parameter,
-    Unit,
 )
 from acidwatch_api.models.datamodel import TextResult
 from acidwatch_api.settings import SETTINGS
 
 
 class PhpitzParameters(BaseParameters):
-    temperature: int = Parameter(
-        300,
-        label="Temperature",
-        unit=Unit.TEMPERATURE_KELVIN,
-        min=200,
-        max=400,
-    )
-
-    pressure: int = Parameter(
-        10,
-        label="Pressure",
-        unit="bara",
-        min=1,
-        max=300,
-    )
+    pass
 
 
 class PhpitzAdapter(BaseAdapter):
@@ -51,6 +35,8 @@ class PhpitzAdapter(BaseAdapter):
     parameters: PhpitzParameters
     category = "Primary"
     base_url = SETTINGS.phpitz_api_base_uri
+    temperature_range = (200.0, 400.0)
+    pressure_range = (1.0, 300.0)
 
     async def run(self) -> RunResult:
         res = await self.client.post(
@@ -59,8 +45,8 @@ class PhpitzAdapter(BaseAdapter):
                 "concentrations": {
                     key.lower(): value for key, value in self.concentrations.items()
                 },
-                "temperature": self.parameters.temperature - 273,
-                "pressure": self.parameters.pressure,
+                "temperature": self.temperature - 273,
+                "pressure": self.pressure,
             },
             timeout=60.0,
         )

--- a/backend/src/acidwatch_api/models/solubilityccs.py
+++ b/backend/src/acidwatch_api/models/solubilityccs.py
@@ -3,7 +3,6 @@ from acidwatch_api.models.base import (
     BaseParameters,
     Parameter,
     RunResult,
-    Unit,
 )
 from acidwatch_api.models.datamodel import TextResult
 
@@ -21,22 +20,6 @@ CO₂-water-HNO₃ (ternary system with nitric acid)"""
 
 
 class SolubilityCCSParameters(BaseParameters):
-    temperature: float = Parameter(
-        288,
-        label="Temperature",
-        unit=Unit.TEMPERATURE_KELVIN,
-        min=173,
-        max=473,
-        description="Temperature in Celsius",
-    )
-    pressure: float = Parameter(
-        100,
-        label="Pressure",
-        unit="bara",
-        min=1.0,
-        max=300,
-        description="Pressure in bara",
-    )
     flow_rate: float = Parameter(
         10,
         label="Flow rate",
@@ -54,14 +37,16 @@ class SolubilityCCSAdapter(BaseAdapter):
     valid_substances = ["H2O", "H2SO4", "HNO3"]
     parameters: SolubilityCCSParameters
     category = "Secondary"
+    temperature_range = (173.0, 473.0)
+    pressure_range = (1.0, 300.0)
 
     async def run(self) -> RunResult:
         # Get concentrations (mole fractions)
         h2o = self.concentrations.get("H2O", 0.0)
         h2so4 = self.concentrations.get("H2SO4", 0.0)
         hno3 = self.concentrations.get("HNO3", 0.0)
-        temp = self.parameters.temperature
-        pres = self.parameters.pressure
+        temp = self.temperature
+        pres = self.pressure
         flow_rate = self.parameters.flow_rate
 
         co2 = 1e6 - (h2o + h2so4 + hno3)

--- a/backend/src/acidwatch_api/routes/models.py
+++ b/backend/src/acidwatch_api/routes/models.py
@@ -88,6 +88,8 @@ def get_models(
                 description=adapter.description,
                 valid_substances=adapter.valid_substances,
                 parameters=get_parameters_schema(adapter),
+                temperature_range=adapter.temperature_range,
+                pressure_range=adapter.pressure_range,
             )
         )
     return models
@@ -201,6 +203,8 @@ def get_result_for_simulation(
 
     simulation_input = Simulation(
         concentrations=db_simulation.concentrations,
+        temperature=db_simulation.temperature,
+        pressure=db_simulation.pressure,
         models=model_inputs,
     )
 
@@ -241,6 +245,8 @@ async def run_simulation(
         try:
             adapter = adapter_class(
                 parameters=model.parameters,
+                temperature=create_simulation.temperature,
+                pressure=create_simulation.pressure,
                 jwt_token=user.jwt_token if user else None,
             )
             adapters.append(adapter)
@@ -278,6 +284,8 @@ async def run_simulation(
     simulation = db.Simulation(
         owner_id=UUID(user.id) if user else None,
         concentrations=create_simulation.concentrations,
+        temperature=create_simulation.temperature,
+        pressure=create_simulation.pressure,
         model_inputs=model_inputs,
     )
     session.add(simulation)

--- a/backend/tests/models/test_gibbs_adapter.py
+++ b/backend/tests/models/test_gibbs_adapter.py
@@ -52,14 +52,16 @@ async def test_only_allowed_components_are_added_by_default(
     )
 
     parameters = {
-        "temperature": 250,
-        "pressure": 10,
         "equation_of_state": _EquationOfState.SRK,
     }
 
     # Act
     adapter = GibbsMinimizationModelAdapter(
-        concentrations=concentrations, parameters=parameters, jwt_token=None
+        concentrations=concentrations,
+        parameters=parameters,
+        temperature=250,
+        pressure=10,
+        jwt_token=None,
     )
     await adapter.run()
 

--- a/backend/tests/test_models_endpoints.py
+++ b/backend/tests/test_models_endpoints.py
@@ -137,7 +137,11 @@ def test_dummy_model_only_valid_substances_are_present(
         response = client.get(f"/simulations/{simulation_id}/result")
         assert response.json() == {
             "status": "done",
-            "input": simulation,
+            "input": {
+                **simulation,
+                "temperature": None,
+                "pressure": None,
+            },
             "results": [{"concentrations": expected_concs, "panels": []}],
         }
 
@@ -195,6 +199,8 @@ def test_dummy_has_correct_parameter_name(client, monkeypatch, dummy_model):
                 }
             },
             "validSubstances": ["H2O"],
+            "temperatureRange": None,
+            "pressureRange": None,
         }
     ]
 
@@ -314,6 +320,8 @@ def test_dummy_model_only_valid_parameters_are_present(
             "status": "done",
             "input": {
                 "concentrations": {},
+                "temperature": None,
+                "pressure": None,
                 "models": [
                     {
                         "modelId": dummy_model.model_id,
@@ -391,7 +399,7 @@ def test_running_models(client, input_models, result_concentrations):
 
     assert response.json() == {
         "status": "done",
-        "input": simulation_input,
+        "input": {**simulation_input, "temperature": None, "pressure": None},
         "results": [{"concentrations": x, "panels": []} for x in result_concentrations],
     }
 
@@ -498,6 +506,11 @@ def test_results_order(client, sql_session, swap):
 
     assert response.json() == {
         "status": "done",
-        "input": {"concentrations": {}, "models": [first_model, second_model]},
+        "input": {
+            "concentrations": {},
+            "temperature": None,
+            "pressure": None,
+            "models": [first_model, second_model],
+        },
         "results": [first_result, second_result],
     }

--- a/frontend/src/components/Simulation/ModelInputs.tsx
+++ b/frontend/src/components/Simulation/ModelInputs.tsx
@@ -9,9 +9,21 @@ import { useModelInputStore, getModelInputStore } from "@/hooks/useModelInputSto
 import { useShallow } from "zustand/react/shallow";
 import { ModelInput } from "@/dto/ModelInput";
 import { useConcentrationsStore } from "@/hooks/useConcentrationsStore";
+import { useConditionsStore } from "@/hooks/useConditionsStore";
 import { sortModelsByCategory } from "@/utils/modelUtils";
 
 const PPM_MAX = 1000000;
+
+// Compute the intersection of optional [min, max] ranges across selected models.
+function intersectRanges(
+    ranges: (readonly [number, number] | null | undefined)[]
+): [number, number] | null | undefined {
+    const present = ranges.filter((r): r is readonly [number, number] => Array.isArray(r));
+    if (present.length === 0) return null;
+    const min = Math.max(...present.map(([lo]) => lo));
+    const max = Math.min(...present.map(([, hi]) => hi));
+    return min <= max ? [min, max] : undefined;
+}
 
 function optionName(option: string): string {
     const mappedValue = FORMULA_TO_NAME_MAPPER[option];
@@ -116,6 +128,17 @@ const ModelInputs: React.FC<{
             setConcentration: s.setConcentration,
         }))
     );
+    const { temperature, pressure, setTemperature, setPressure } = useConditionsStore(
+        useShallow((s) => ({
+            temperature: s.temperature,
+            pressure: s.pressure,
+            setTemperature: s.setTemperature,
+            setPressure: s.setPressure,
+        }))
+    );
+
+    const temperatureRange = intersectRanges(selectedModels.map((m) => m.temperatureRange));
+    const pressureRange = intersectRanges(selectedModels.map((m) => m.pressureRange));
 
     const firstModelValidSubstances =
         selectedModels.length > 0 ? new Set(selectedModels[0].validSubstances) : new Set<string>();
@@ -139,7 +162,13 @@ const ModelInputs: React.FC<{
             };
         });
 
-        onSubmit({ concentrations: validConcentrations, models });
+        onSubmit({
+            concentrations: validConcentrations,
+            // Only send conditions when at least one selected model consumes them.
+            temperature: temperatureRange !== null ? temperature : null,
+            pressure: pressureRange !== null ? pressure : null,
+            models,
+        });
     };
 
     const hasInvalidSubstances = Object.keys(concentrations).some(
@@ -148,6 +177,18 @@ const ModelInputs: React.FC<{
     const hasNoValidSubstances = Object.keys(concentrations).every(
         (substance) => selectedModels.length > 0 && !firstModelValidSubstances.has(substance)
     );
+
+    // null  → no selected model uses this condition (hide input)
+    // undefined → selected models have no overlapping range (show error)
+    // tuple → intersection of allowed ranges across selected models
+    const showTemperature = temperatureRange !== null;
+    const showPressure = pressureRange !== null;
+    const showConditions = showTemperature || showPressure;
+    const hasEmptyRangeIntersection = temperatureRange === undefined || pressureRange === undefined;
+
+    const conditionsOutOfRange =
+        (temperatureRange && (temperature < temperatureRange[0] || temperature > temperatureRange[1])) ||
+        (pressureRange && (pressure < pressureRange[0] || pressure > pressureRange[1]));
 
     return (
         <div>
@@ -180,10 +221,53 @@ const ModelInputs: React.FC<{
                     })}
                     <SubstanceAdder invisible={invisible} onAdd={(item: string) => setConcentration(item, 0)} />
                 </div>
+                {showConditions && (
+                    <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+                        <Typography variant="h3">Conditions</Typography>
+                        {showTemperature && (
+                            <ConvertibleTextField
+                                convertibleUnit="kelvin"
+                                value={temperature}
+                                label="Temperature"
+                                min={temperatureRange?.[0]}
+                                max={temperatureRange?.[1]}
+                                meta={MetaTooltip(
+                                    temperatureRange
+                                        ? `Allowed range: ${temperatureRange[0]}–${temperatureRange[1]} K (intersection of selected models)`
+                                        : "Selected models have no overlapping temperature range"
+                                )}
+                                onValueChange={(value: number) => setTemperature(value)}
+                            />
+                        )}
+                        {showPressure && (
+                            <ConvertibleTextField
+                                value={pressure}
+                                label="Pressure"
+                                unit="bara"
+                                min={pressureRange?.[0]}
+                                max={pressureRange?.[1]}
+                                meta={MetaTooltip(
+                                    pressureRange
+                                        ? `Allowed range: ${pressureRange[0]}–${pressureRange[1]} bara (intersection of selected models)`
+                                        : "Selected models have no overlapping pressure range"
+                                )}
+                                onValueChange={(value: number) => setPressure(value)}
+                            />
+                        )}
+                    </div>
+                )}
                 {selectedModels.map((model) => (
                     <ModelParametersWrapper key={model.modelId} model={model} />
                 ))}
             </Columns>
+            {showConditions && hasEmptyRangeIntersection && (
+                <Typography
+                    variant="body_short"
+                    style={{ marginTop: "1em", color: "var(--eds_interactive_danger__text, #eb0037)" }}
+                >
+                    ⚠️ Selected models have no overlapping temperature/pressure range. Pick a different combination.
+                </Typography>
+            )}
             {hasInvalidSubstances && (
                 <Typography
                     variant="body_short"
@@ -195,7 +279,12 @@ const ModelInputs: React.FC<{
             <Button
                 style={{ marginTop: "1em" }}
                 onClick={handleSubmit}
-                disabled={hasNoValidSubstances || selectedModels.length === 0}
+                disabled={
+                    hasNoValidSubstances ||
+                    selectedModels.length === 0 ||
+                    (showConditions && hasEmptyRangeIntersection) ||
+                    !!conditionsOutOfRange
+                }
             >
                 Run Simulation
             </Button>

--- a/frontend/src/dto/FormConfig.ts
+++ b/frontend/src/dto/FormConfig.ts
@@ -20,5 +20,7 @@ export const ModelConfig = z.object({
     parameters: z.record(z.string(), ParameterConfig),
     description: z.string(),
     category: z.enum(["Primary", "Secondary"]),
+    temperatureRange: z.nullable(z.tuple([z.number(), z.number()])).optional(),
+    pressureRange: z.nullable(z.tuple([z.number(), z.number()])).optional(),
 });
 export type ModelConfig = z.infer<typeof ModelConfig>;

--- a/frontend/src/dto/ModelInput.ts
+++ b/frontend/src/dto/ModelInput.ts
@@ -2,6 +2,8 @@
 
 export const ModelInput = z.object({
     concentrations: z.record(z.string(), z.number()),
+    temperature: z.nullable(z.number()).optional(),
+    pressure: z.nullable(z.number()).optional(),
     models: z.array(
         z.object({
             parameters: z.record(z.string(), z.union([z.number(), z.string()])),

--- a/frontend/src/hooks/useConditionsStore.ts
+++ b/frontend/src/hooks/useConditionsStore.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+
+export interface ConditionsState {
+    temperature: number;
+    pressure: number;
+    setTemperature: (value: number) => void;
+    setPressure: (value: number) => void;
+    reset: (state?: { temperature?: number | null; pressure?: number | null }) => void;
+}
+
+const DEFAULTS = { temperature: 298, pressure: 100 };
+
+export const useConditionsStore = create<ConditionsState>((set) => ({
+    ...DEFAULTS,
+
+    setTemperature: (temperature) => set({ temperature }),
+    setPressure: (pressure) => set({ pressure }),
+
+    reset: (state) =>
+        set({
+            temperature: state?.temperature ?? DEFAULTS.temperature,
+            pressure: state?.pressure ?? DEFAULTS.pressure,
+        }),
+}));

--- a/frontend/src/pages/Models.tsx
+++ b/frontend/src/pages/Models.tsx
@@ -10,6 +10,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { simulationHistory } from "@/hooks/useSimulationHistory.ts";
 import { getModelInputStore } from "@/hooks/useModelInputStore";
 import { useConcentrationsStore } from "@/hooks/useConcentrationsStore";
+import { useConditionsStore } from "@/hooks/useConditionsStore";
 import InputStep from "@/components/Simulation/InputStep";
 import ResultStep from "@/components/Simulation/ResultStep";
 
@@ -65,6 +66,10 @@ const Models: React.FC = () => {
             });
 
             useConcentrationsStore.getState().reset(simulationResults.input.concentrations);
+            useConditionsStore.getState().reset({
+                temperature: simulationResults.input.temperature,
+                pressure: simulationResults.input.pressure,
+            });
             setSelectedModels(loadedModels);
         }
     }, [simulationResults, models]);


### PR DESCRIPTION
Closes #636.

Lifts `temperature` and `pressure` out of each adapter's parameters
schema and into top-level simulation conditions, so they're entered
once and shared across primary and secondary models.

### Backend
- `BaseAdapter` accepts `temperature`/`pressure` kwargs and validates
  them against optional `temperature_range`/`pressure_range` class
  attributes; validation errors surface under a new `conditions` key.
- T/P removed from `*Parameters` classes in `arcs`, `arcs_exp`,
  `gibbs_minimization_model`, `phpitz`, `solubilityccs`. Each adapter
  now declares its supported ranges. ToCoMo unchanged (no T/P).
- `Simulation` and `ModelInfo` Pydantic models gain `temperature`,
  `pressure`, `temperature_range`, `pressure_range`.
- `simulations` table gains nullable `temperature`/`pressure` columns.
- Alembic migration `7c2e9a4b1f3d_separate_conditions` lifts existing
  values out of `model_inputs.parameters` JSON into the new columns.

### Frontend
- New `useConditionsStore` holds the shared T/P values.
- `ModelInputs` renders a Conditions block below Concentrations, using
  the **intersection** of the selected models' supported ranges. The
  block is hidden when no selected model needs T/P (e.g. ToCoMo only),
  in which case `null` is sent to the API.
- `Models` page restores T/P when reloading a historical simulation.
- DTOs (`ModelInput`, `FormConfig`) extended with the new fields.