### PR TITLE
Separate temperature and pressure from model parameters (#636)

### DIFF
--- a/backend/alembic/versions/9b4e2c1a7d50_add_conditions_to_simulation.py
+++ b/backend/alembic/versions/9b4e2c1a7d50_add_conditions_to_simulation.py
@@ -1,0 +1,118 @@
+"""add conditions to simulation
+
+Revision ID: 9b4e2c1a7d50
+Revises: 01aaa143d690
+Create Date: 2026-05-06 00:00:00.000000
+
+"""
+
+import json
+from typing import Any, Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "9b4e2c1a7d50"
+down_revision: Union[str, Sequence[str], None] = "01aaa143d690"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_CONDITION_KEYS = ("temperature", "pressure")
+
+
+def _as_dict(value: Any) -> dict:
+    if value is None:
+        return {}
+    if isinstance(value, str):
+        return json.loads(value or "{}")
+    return dict(value)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "simulations",
+        sa.Column(
+            "conditions",
+            sa.JSON(),
+            nullable=True,
+        ),
+    )
+
+    # Backfill: lift temperature/pressure from each model_input's parameters
+    # up to the parent simulation's new conditions column.
+    bind = op.get_bind()
+    simulations = sa.table(
+        "simulations",
+        sa.column("id", sa.Uuid()),
+        sa.column("conditions", sa.JSON()),
+    )
+    model_inputs = sa.table(
+        "model_inputs",
+        sa.column("id", sa.Uuid()),
+        sa.column("simulation_id", sa.Uuid()),
+        sa.column("parameters", sa.JSON()),
+    )
+
+    rows = bind.execute(
+        sa.select(
+            model_inputs.c.id, model_inputs.c.simulation_id, model_inputs.c.parameters
+        )
+    ).all()
+
+    sim_conditions: dict = {}
+    for mi_id, sim_id, params in rows:
+        params = _as_dict(params)
+        extracted = {k: params.pop(k) for k in _CONDITION_KEYS if k in params}
+        if extracted:
+            # Last writer wins if model_inputs disagree; they should match in practice.
+            sim_conditions.setdefault(sim_id, {}).update(extracted)
+            bind.execute(
+                sa.update(model_inputs)
+                .where(model_inputs.c.id == mi_id)
+                .values(parameters=params)
+            )
+
+    for sim_id, conditions in sim_conditions.items():
+        bind.execute(
+            sa.update(simulations)
+            .where(simulations.c.id == sim_id)
+            .values(conditions=conditions)
+        )
+
+
+def downgrade() -> None:
+    # Push conditions back into each model_input's parameters before dropping the column.
+    bind = op.get_bind()
+    simulations = sa.table(
+        "simulations",
+        sa.column("id", sa.Uuid()),
+        sa.column("conditions", sa.JSON()),
+    )
+    model_inputs = sa.table(
+        "model_inputs",
+        sa.column("id", sa.Uuid()),
+        sa.column("simulation_id", sa.Uuid()),
+        sa.column("parameters", sa.JSON()),
+    )
+
+    sim_rows = bind.execute(sa.select(simulations.c.id, simulations.c.conditions)).all()
+    for sim_id, conditions in sim_rows:
+        conditions = _as_dict(conditions)
+        if not conditions:
+            continue
+        mi_rows = bind.execute(
+            sa.select(model_inputs.c.id, model_inputs.c.parameters).where(
+                model_inputs.c.simulation_id == sim_id
+            )
+        ).all()
+        for mi_id, params in mi_rows:
+            merged = {**conditions, **_as_dict(params)}
+            bind.execute(
+                sa.update(model_inputs)
+                .where(model_inputs.c.id == mi_id)
+                .values(parameters=merged)
+            )
+
+    op.drop_column("simulations", "conditions")

--- a/backend/src/acidwatch_api/database.py
+++ b/backend/src/acidwatch_api/database.py
@@ -45,6 +45,7 @@ class Simulation(Base):
 
     owner_id: Mapped[UUID | None] = mapped_column(Uuid)
     concentrations: Mapped[dict[str, float]] = mapped_column(JSON)
+    conditions: Mapped[dict[str, float] | None] = mapped_column(JSON)
 
     model_inputs: Mapped[list[ModelInput]] = relationship(back_populates="simulation")
 

--- a/backend/src/acidwatch_api/models/arcs.py
+++ b/backend/src/acidwatch_api/models/arcs.py
@@ -2,10 +2,7 @@ from acidwatch_api.models.datamodel import ReactionPathsResult
 
 from acidwatch_api.models.base import (
     BaseAdapter,
-    BaseParameters,
-    Parameter,
     RunResult,
-    Unit,
 )
 from acidwatch_api.settings import SETTINGS
 
@@ -15,26 +12,6 @@ DESCRIPTION: str = """Automated Reactions for CO2 Storage (ARCS) model.
     
     Source code found at https://github.com/equinor/arcs/tree/21ded96960d28d549c0950fbc1aa09c94159f652
     """
-
-
-class ArcsParameters(BaseParameters):
-    temperature: int = Parameter(
-        300,
-        label="Temperature",
-        unit=Unit.TEMPERATURE_KELVIN,
-        min=200,
-        max=400,
-        description="Temperature in Celsius",
-    )
-
-    pressure: int = Parameter(
-        10,
-        label="Pressure",
-        unit="bara",
-        min=1,
-        max=300,
-        description="Pressure in bara",
-    )
 
 
 class ArcsAdapter(BaseAdapter):
@@ -69,7 +46,6 @@ class ArcsAdapter(BaseAdapter):
         "NOHSO4",
     ]
 
-    parameters: ArcsParameters
     base_url = SETTINGS.arcs_api_base_uri
 
     async def run(self) -> RunResult:
@@ -79,8 +55,8 @@ class ArcsAdapter(BaseAdapter):
                 "concs": {
                     key: value / 1e6 for key, value in self.concentrations.items()
                 },
-                "temperature": self.parameters.temperature,
-                "pressure": self.parameters.pressure,
+                "temperature": self.conditions.temperature,
+                "pressure": self.conditions.pressure,
                 "samples": 2000,  # Default to 2000 samples
             },
             timeout=300.0,

--- a/backend/src/acidwatch_api/models/arcs_exp.py
+++ b/backend/src/acidwatch_api/models/arcs_exp.py
@@ -1,9 +1,6 @@
 from acidwatch_api.models.base import (
     BaseAdapter,
-    BaseParameters,
-    Parameter,
     RunResult,
-    Unit,
 )
 from acidwatch_api.settings import SETTINGS
 
@@ -14,26 +11,6 @@ DESCRIPTION: str = """Automated Reactions for CO2 Storage (ARCS) model.
     This model is under significant development and expected to deviate while developed. Therefore a development version of it has been released while work is ongoing
     Source code found at https://github.com/badw/arcs
     """
-
-
-class ArcsParameters(BaseParameters):
-    temperature: int = Parameter(
-        300,
-        label="Temperature",
-        unit=Unit.TEMPERATURE_KELVIN,
-        min=200,
-        max=400,
-        description="Temperature in Celsius",
-    )
-
-    pressure: int = Parameter(
-        10,
-        label="Pressure",
-        unit="bara",
-        min=1,
-        max=300,
-        description="Pressure in bara",
-    )
 
 
 class ArcsExpAdapter(BaseAdapter):
@@ -68,7 +45,6 @@ class ArcsExpAdapter(BaseAdapter):
         "NOHSO4",
     ]
 
-    parameters: ArcsParameters
     base_url = SETTINGS.arcs_exp_api_base_uri
 
     async def run(self) -> RunResult:
@@ -78,8 +54,8 @@ class ArcsExpAdapter(BaseAdapter):
                 "concs": {
                     key: value / 1e6 for key, value in self.concentrations.items()
                 },
-                "temperature": self.parameters.temperature,
-                "pressure": self.parameters.pressure,
+                "temperature": self.conditions.temperature,
+                "pressure": self.conditions.pressure,
                 "samples": 500,
             },
             timeout=300.0,

--- a/backend/src/acidwatch_api/models/base.py
+++ b/backend/src/acidwatch_api/models/base.py
@@ -31,7 +31,7 @@ from pydantic.config import JsonDict
 from typing_extensions import Doc
 
 from acidwatch_api.authentication import acquire_token_for_downstream_api
-from acidwatch_api.models.datamodel import AnyPanel
+from acidwatch_api.models.datamodel import AnyPanel, Conditions
 
 
 class InputError(ValueError):
@@ -190,16 +190,21 @@ def get_parameters_schema(cls: type[BaseAdapter]) -> Any:
 
 
 class BaseAdapter:
+    conditions: Conditions
+
     def __init__(
         self,
         *,
         concentrations: dict[str, int | float] | None = None,
         parameters: dict[str, str | bool | int | float] | None,
+        conditions: Conditions | None = None,
         jwt_token: str | None,
     ) -> None:
         if concentrations is not None:
             self.validate_concentrations(concentrations)
             self.set_concentrations(concentrations)
+
+        self.conditions = conditions if conditions is not None else Conditions()
 
         parameters_type = _get_parameters_type(type(self))
         if parameters and parameters_type is None:

--- a/backend/src/acidwatch_api/models/datamodel.py
+++ b/backend/src/acidwatch_api/models/datamodel.py
@@ -19,8 +19,14 @@ class ModelInput(_BaseModel):
     parameters: dict[str, bool | float | int | str]
 
 
+class Conditions(_BaseModel):
+    temperature: float = 300
+    pressure: float = 10
+
+
 class Simulation(_BaseModel):
     concentrations: dict[str, int | float]
+    conditions: Conditions = Field(default_factory=Conditions)
     models: list[ModelInput] = Field(min_length=1)
 
 

--- a/backend/src/acidwatch_api/models/gibbs_minimization_model.py
+++ b/backend/src/acidwatch_api/models/gibbs_minimization_model.py
@@ -145,7 +145,7 @@ class GibbsMinimizationModelAdapter(BaseAdapter):
     async def run(self) -> RunResult:
         eos = self.parameters.equation_of_state
         temperature = self.conditions.temperature
-        pressure= self.conditions.pressure
+        pressure = self.conditions.pressure
 
         if eos == _EquationOfState.SRK:
             system = jneqsim.thermo.system.SystemSrkEos(temperature, pressure)

--- a/backend/src/acidwatch_api/models/gibbs_minimization_model.py
+++ b/backend/src/acidwatch_api/models/gibbs_minimization_model.py
@@ -5,7 +5,6 @@ from acidwatch_api.models.base import (
     BaseParameters,
     Parameter,
     RunResult,
-    Unit,
 )
 
 # Model constants
@@ -90,20 +89,6 @@ class _EquationOfState(StrEnum):
 
 
 class GibbsMinimizationModelParameters(BaseParameters):
-    temperature: int = Parameter(
-        298,
-        label="Temperature",
-        unit=Unit.TEMPERATURE_KELVIN,
-        min=200,
-        max=450,
-    )
-    pressure: int = Parameter(
-        100,
-        label="Pressure",
-        unit="bara",
-        min=1,
-        max=300,
-    )
     equation_of_state: _EquationOfState = Parameter(
         _EquationOfState.SRK,
         label="Equation of State",
@@ -159,17 +144,17 @@ class GibbsMinimizationModelAdapter(BaseAdapter):
 
     async def run(self) -> RunResult:
         eos = self.parameters.equation_of_state
-        temp = self.parameters.temperature
-        pres = self.parameters.pressure
+        temperature = self.conditions.temperature
+        pressure= self.conditions.pressure
 
         if eos == _EquationOfState.SRK:
-            system = jneqsim.thermo.system.SystemSrkEos(temp, pres)
+            system = jneqsim.thermo.system.SystemSrkEos(temperature, pressure)
         elif eos == _EquationOfState.PR:
-            system = jneqsim.thermo.system.SystemPrEos(temp, pres)
+            system = jneqsim.thermo.system.SystemPrEos(temperature, pressure)
         elif eos == _EquationOfState.SRKCPA:
-            system = jneqsim.thermo.system.SystemSrkCPAstatoil(temp, pres)
+            system = jneqsim.thermo.system.SystemSrkCPAstatoil(temperature, pressure)
         elif eos == _EquationOfState.IdealGas:
-            system = jneqsim.thermo.system.SystemIdealGas(temp, pres)
+            system = jneqsim.thermo.system.SystemIdealGas(temperature, pressure)
         else:
             raise NotImplementedError(f"Equation of state not implemented: {eos}")
 
@@ -191,8 +176,8 @@ class GibbsMinimizationModelAdapter(BaseAdapter):
 
         # # Create an inlet stream
         inlet_stream = jneqsim.process.equipment.stream.Stream("Inlet Stream", system)
-        inlet_stream.setPressure(self.parameters.pressure, "bara")
-        inlet_stream.setTemperature(self.parameters.temperature, "K")
+        inlet_stream.setPressure(pressure, "bara")
+        inlet_stream.setTemperature(temperature, "K")
         inlet_stream.run()
 
         # Create a Gibbs reactor

--- a/backend/src/acidwatch_api/models/phpitz.py
+++ b/backend/src/acidwatch_api/models/phpitz.py
@@ -2,31 +2,10 @@ from __future__ import annotations
 
 from acidwatch_api.models.base import (
     BaseAdapter,
-    BaseParameters,
     RunResult,
-    Parameter,
-    Unit,
 )
 from acidwatch_api.models.datamodel import TextResult
 from acidwatch_api.settings import SETTINGS
-
-
-class PhpitzParameters(BaseParameters):
-    temperature: int = Parameter(
-        300,
-        label="Temperature",
-        unit=Unit.TEMPERATURE_KELVIN,
-        min=200,
-        max=400,
-    )
-
-    pressure: int = Parameter(
-        10,
-        label="Pressure",
-        unit="bara",
-        min=1,
-        max=300,
-    )
 
 
 class PhpitzAdapter(BaseAdapter):
@@ -48,7 +27,6 @@ class PhpitzAdapter(BaseAdapter):
     ]
     description = "Computational model developed by Baard Kaasa as part of our CCS research on CO2 Impurities."
 
-    parameters: PhpitzParameters
     category = "Primary"
     base_url = SETTINGS.phpitz_api_base_uri
 
@@ -59,8 +37,8 @@ class PhpitzAdapter(BaseAdapter):
                 "concentrations": {
                     key.lower(): value for key, value in self.concentrations.items()
                 },
-                "temperature": self.parameters.temperature - 273,
-                "pressure": self.parameters.pressure,
+                "temperature": self.conditions.temperature - 273,
+                "pressure": self.conditions.pressure,
             },
             timeout=60.0,
         )

--- a/backend/src/acidwatch_api/models/solubilityccs.py
+++ b/backend/src/acidwatch_api/models/solubilityccs.py
@@ -3,7 +3,6 @@ from acidwatch_api.models.base import (
     BaseParameters,
     Parameter,
     RunResult,
-    Unit,
 )
 from acidwatch_api.models.datamodel import TextResult
 
@@ -21,22 +20,6 @@ CO₂-water-HNO₃ (ternary system with nitric acid)"""
 
 
 class SolubilityCCSParameters(BaseParameters):
-    temperature: float = Parameter(
-        288,
-        label="Temperature",
-        unit=Unit.TEMPERATURE_KELVIN,
-        min=173,
-        max=473,
-        description="Temperature in Celsius",
-    )
-    pressure: float = Parameter(
-        100,
-        label="Pressure",
-        unit="bara",
-        min=1.0,
-        max=300,
-        description="Pressure in bara",
-    )
     flow_rate: float = Parameter(
         10,
         label="Flow rate",
@@ -60,8 +43,8 @@ class SolubilityCCSAdapter(BaseAdapter):
         h2o = self.concentrations.get("H2O", 0.0)
         h2so4 = self.concentrations.get("H2SO4", 0.0)
         hno3 = self.concentrations.get("HNO3", 0.0)
-        temp = self.parameters.temperature
-        pres = self.parameters.pressure
+        temp = self.conditions.temperature
+        pres = self.conditions.pressure
         flow_rate = self.parameters.flow_rate
 
         co2 = 1e6 - (h2o + h2so4 + hno3)

--- a/backend/src/acidwatch_api/routes/models.py
+++ b/backend/src/acidwatch_api/routes/models.py
@@ -16,6 +16,7 @@ from acidwatch_api.authentication import (
 from acidwatch_api.database import GetDB, SessionMaker
 from acidwatch_api.models.datamodel import (
     AnyPanel,
+    Conditions,
     ModelInfo,
     ModelInput,
     ModelResult,
@@ -201,6 +202,7 @@ def get_result_for_simulation(
 
     simulation_input = Simulation(
         concentrations=db_simulation.concentrations,
+        conditions=Conditions(**(db_simulation.conditions or {})),
         models=model_inputs,
     )
 
@@ -241,6 +243,7 @@ async def run_simulation(
         try:
             adapter = adapter_class(
                 parameters=model.parameters,
+                conditions=create_simulation.conditions,
                 jwt_token=user.jwt_token if user else None,
             )
             adapters.append(adapter)
@@ -278,6 +281,7 @@ async def run_simulation(
     simulation = db.Simulation(
         owner_id=UUID(user.id) if user else None,
         concentrations=create_simulation.concentrations,
+        conditions=create_simulation.conditions.model_dump(),
         model_inputs=model_inputs,
     )
     session.add(simulation)

--- a/backend/tests/migrations/test_add_conditions.py
+++ b/backend/tests/migrations/test_add_conditions.py
@@ -1,0 +1,93 @@
+import json
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import text
+
+
+def _json_value(value):
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
+def test_migration_moves_conditions_up_and_down(alembic_runner, alembic_engine):
+    alembic_runner.migrate_up_before("9b4e2c1a7d50")
+
+    simulation_id = UUID(int=100)
+    model_input_id = UUID(int=101)
+    result_id = UUID(int=102)
+
+    simulation_data = {
+        "created_at": datetime.now(),
+        "updated_at": datetime.now(),
+        "id": simulation_id,
+        "owner_id": None,
+        "concentrations": '{"H2O": 2.0}',
+    }
+
+    alembic_runner.insert_into("simulations", simulation_data)
+
+    model_input_data = {
+        "created_at": datetime.now(),
+        "updated_at": datetime.now(),
+        "id": model_input_id,
+        "simulation_id": simulation_id,
+        "previous_model_input_id": None,
+        "model_id": "gibbs",
+        "parameters": '{"temperature": 300, "pressure": 10, "equation_of_state": "SRK"}',
+    }
+    alembic_runner.insert_into("model_inputs", model_input_data)
+
+    result_data = {
+        "created_at": datetime.now(),
+        "updated_at": datetime.now(),
+        "id": result_id,
+        "model_input_id": model_input_id,
+        "concentrations": '{"H2O": 1.0}',
+        "panels": "[]",
+    }
+    alembic_runner.insert_into("results", result_data)
+
+    alembic_runner.migrate_up_one()
+
+    with alembic_engine.connect() as conn:
+        simulation_row = conn.execute(
+            text("SELECT conditions FROM simulations WHERE id = :simulation_id"),
+            {"simulation_id": simulation_id},
+        ).fetchone()
+        assert simulation_row is not None
+        assert _json_value(simulation_row[0]) == {"temperature": 300, "pressure": 10}
+
+        model_input_row = conn.execute(
+            text("SELECT parameters FROM model_inputs WHERE id = :model_input_id"),
+            {"model_input_id": model_input_id},
+        ).fetchone()
+        assert model_input_row is not None
+        assert _json_value(model_input_row[0]) == {"equation_of_state": "SRK"}
+
+        result_row = conn.execute(
+            text("SELECT model_input_id FROM results WHERE id = :result_id"),
+            {"result_id": result_id},
+        ).fetchone()
+        assert result_row == (model_input_id,)
+
+    alembic_runner.migrate_down_one()
+
+    with alembic_engine.connect() as conn:
+        model_input_row = conn.execute(
+            text("SELECT parameters FROM model_inputs WHERE id = :model_input_id"),
+            {"model_input_id": model_input_id},
+        ).fetchone()
+        assert model_input_row is not None
+        assert _json_value(model_input_row[0]) == {
+            "temperature": 300,
+            "pressure": 10,
+            "equation_of_state": "SRK",
+        }
+
+        result_row = conn.execute(
+            text("SELECT model_input_id FROM results WHERE id = :result_id"),
+            {"result_id": result_id},
+        ).fetchone()
+        assert result_row == (model_input_id,)

--- a/backend/tests/models/test_gibbs_adapter.py
+++ b/backend/tests/models/test_gibbs_adapter.py
@@ -4,6 +4,7 @@ from acidwatch_api.models.gibbs_minimization_model import (
     NOT_INITIALIZED_BY_DEFAULT,
     INITIALIZED_BY_DEFAULT,
 )
+from acidwatch_api.models.datamodel import Conditions
 import pytest
 from neqsim import jneqsim
 from unittest.mock import MagicMock
@@ -52,14 +53,15 @@ async def test_only_allowed_components_are_added_by_default(
     )
 
     parameters = {
-        "temperature": 250,
-        "pressure": 10,
         "equation_of_state": _EquationOfState.SRK,
     }
 
     # Act
     adapter = GibbsMinimizationModelAdapter(
-        concentrations=concentrations, parameters=parameters, jwt_token=None
+        concentrations=concentrations,
+        parameters=parameters,
+        conditions=Conditions(temperature=250, pressure=10),
+        jwt_token=None,
     )
     await adapter.run()
 

--- a/backend/tests/test_models_endpoints.py
+++ b/backend/tests/test_models_endpoints.py
@@ -137,7 +137,10 @@ def test_dummy_model_only_valid_substances_are_present(
         response = client.get(f"/simulations/{simulation_id}/result")
         assert response.json() == {
             "status": "done",
-            "input": simulation,
+            "input": {
+                **simulation,
+                "conditions": {"temperature": 300.0, "pressure": 10.0},
+            },
             "results": [{"concentrations": expected_concs, "panels": []}],
         }
 
@@ -314,6 +317,7 @@ def test_dummy_model_only_valid_parameters_are_present(
             "status": "done",
             "input": {
                 "concentrations": {},
+                "conditions": {"temperature": 300.0, "pressure": 10.0},
                 "models": [
                     {
                         "modelId": dummy_model.model_id,
@@ -391,7 +395,10 @@ def test_running_models(client, input_models, result_concentrations):
 
     assert response.json() == {
         "status": "done",
-        "input": simulation_input,
+        "input": {
+            **simulation_input,
+            "conditions": {"temperature": 300.0, "pressure": 10.0},
+        },
         "results": [{"concentrations": x, "panels": []} for x in result_concentrations],
     }
 
@@ -498,6 +505,10 @@ def test_results_order(client, sql_session, swap):
 
     assert response.json() == {
         "status": "done",
-        "input": {"concentrations": {}, "models": [first_model, second_model]},
+        "input": {
+            "concentrations": {},
+            "conditions": {"temperature": 300.0, "pressure": 10.0},
+            "models": [first_model, second_model],
+        },
         "results": [first_result, second_result],
     }

--- a/frontend/src/components/Simulation/ModelInputs.tsx
+++ b/frontend/src/components/Simulation/ModelInputs.tsx
@@ -9,6 +9,7 @@ import { useModelInputStore, getModelInputStore } from "@/hooks/useModelInputSto
 import { useShallow } from "zustand/react/shallow";
 import { ModelInput } from "@/dto/ModelInput";
 import { useConcentrationsStore } from "@/hooks/useConcentrationsStore";
+import { useConditionsStore } from "@/hooks/useConditionsStore";
 import { sortModelsByCategory } from "@/utils/modelUtils";
 
 const PPM_MAX = 1000000;
@@ -116,6 +117,12 @@ const ModelInputs: React.FC<{
             setConcentration: s.setConcentration,
         }))
     );
+    const { conditions, setCondition } = useConditionsStore(
+        useShallow((s) => ({
+            conditions: s.conditions,
+            setCondition: s.setCondition,
+        }))
+    );
 
     const firstModelValidSubstances =
         selectedModels.length > 0 ? new Set(selectedModels[0].validSubstances) : new Set<string>();
@@ -139,7 +146,7 @@ const ModelInputs: React.FC<{
             };
         });
 
-        onSubmit({ concentrations: validConcentrations, models });
+        onSubmit({ concentrations: validConcentrations, conditions, models });
     };
 
     const hasInvalidSubstances = Object.keys(concentrations).some(
@@ -179,6 +186,35 @@ const ModelInputs: React.FC<{
                         );
                     })}
                     <SubstanceAdder invisible={invisible} onAdd={(item: string) => setConcentration(item, 0)} />
+                </div>
+                <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+                    <Typography variant="h3">Conditions</Typography>
+                    <TextField
+                        type="number"
+                        id="temperature"
+                        label="Temperature"
+                        unit="K"
+                        step="any"
+                        value={conditions.temperature}
+                        onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                            if (Number.isFinite(e.target.valueAsNumber)) {
+                                setCondition("temperature", e.target.valueAsNumber);
+                            }
+                        }}
+                    />
+                    <TextField
+                        type="number"
+                        id="pressure"
+                        label="Pressure"
+                        unit="bara"
+                        step="any"
+                        value={conditions.pressure}
+                        onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                            if (Number.isFinite(e.target.valueAsNumber)) {
+                                setCondition("pressure", e.target.valueAsNumber);
+                            }
+                        }}
+                    />
                 </div>
                 {selectedModels.map((model) => (
                     <ModelParametersWrapper key={model.modelId} model={model} />

--- a/frontend/src/dto/ModelInput.ts
+++ b/frontend/src/dto/ModelInput.ts
@@ -2,6 +2,10 @@
 
 export const ModelInput = z.object({
     concentrations: z.record(z.string(), z.number()),
+    conditions: z.object({
+        temperature: z.number(),
+        pressure: z.number(),
+    }),
     models: z.array(
         z.object({
             parameters: z.record(z.string(), z.union([z.number(), z.string()])),
@@ -11,3 +15,4 @@ export const ModelInput = z.object({
 });
 
 export type ModelInput = z.infer<typeof ModelInput>;
+export type Conditions = ModelInput["conditions"];

--- a/frontend/src/functions/Formatting.tsx
+++ b/frontend/src/functions/Formatting.tsx
@@ -92,7 +92,7 @@ export const convertSimulationQueriesResultToTabulatedData = (
                     `${simulation.input.models[0].modelId || "Unknown"} - ${experimentName}`,
                     simulation.input.concentrations,
                     simulation.results[0].concentrations,
-                    simulation.input.models[0].parameters
+                    { ...simulation.input.conditions, ...simulation.input.models[0].parameters }
                 )
             );
         });

--- a/frontend/src/hooks/useConditionsStore.ts
+++ b/frontend/src/hooks/useConditionsStore.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+import { Conditions } from "@/dto/ModelInput";
+
+const DEFAULTS: Conditions = {
+    temperature: 300,
+    pressure: 10,
+};
+
+export interface ConditionsState {
+    conditions: Conditions;
+    setCondition: (key: keyof Conditions, value: number) => void;
+    reset: (conditions?: Conditions) => void;
+}
+
+export const useConditionsStore = create<ConditionsState>((set) => ({
+    conditions: { ...DEFAULTS },
+
+    setCondition: (key, value) => set((s) => ({ conditions: { ...s.conditions, [key]: value } })),
+
+    reset: (conditions) =>
+        set({
+            conditions: conditions ?? { ...DEFAULTS },
+        }),
+}));

--- a/frontend/src/hooks/useSimulationQueriesResult.ts
+++ b/frontend/src/hooks/useSimulationQueriesResult.ts
@@ -51,7 +51,7 @@ export const useSimulationQueries = (): {
             const concentrations = Object.fromEntries(
                 Object.entries(experiment.initialConcentrations).filter(([, value]) => Number(value) !== 0)
             );
-            const parameters = {
+            const conditions = {
                 pressure: experiment?.pressure ?? 0,
                 temperature: 273 + (experiment.temperature ?? 0),
             };
@@ -60,10 +60,11 @@ export const useSimulationQueries = (): {
             try {
                 simulationId = await startSimulation({
                     concentrations,
+                    conditions,
                     models: [
                         {
                             modelId,
-                            parameters,
+                            parameters: {},
                         },
                     ],
                 });

--- a/frontend/src/pages/Models.tsx
+++ b/frontend/src/pages/Models.tsx
@@ -10,6 +10,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { simulationHistory } from "@/hooks/useSimulationHistory.ts";
 import { getModelInputStore } from "@/hooks/useModelInputStore";
 import { useConcentrationsStore } from "@/hooks/useConcentrationsStore";
+import { useConditionsStore } from "@/hooks/useConditionsStore";
 import InputStep from "@/components/Simulation/InputStep";
 import ResultStep from "@/components/Simulation/ResultStep";
 
@@ -65,6 +66,7 @@ const Models: React.FC = () => {
             });
 
             useConcentrationsStore.getState().reset(simulationResults.input.concentrations);
+            useConditionsStore.getState().reset(simulationResults.input.conditions);
             setSelectedModels(loadedModels);
         }
     }, [simulationResults, models]);


### PR DESCRIPTION
Lifts temperature and pressure out of each model adapter's parameters schema and into top-level simulation conditions, so they're entered once and shared across primary and secondary models.

No need to specify default temp and pressure for each model