### PR TITLE
Use git-lfs from ubuntu repo

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,6 @@
 FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu
 
-RUN apt-get install -y curl
-
-RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
+RUN apt-get update && apt-get install -y curl
 
 RUN curl -s https://deb.nodesource.com/setup_22.x | bash 
     


### PR DESCRIPTION
Checked version in the ubuntu image (3.7.1-1), pretty much up to date.
The external repository fails when building, due to missing resolute repo.

Likely this worked with a different image.
