### PR TITLE
Disable git cone mode

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           sparse-checkout: backend/packages/acidwatch
+          sparse-checkout-cone-mode: false
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v3

--- a/.github/workflows/python-packages.yaml
+++ b/.github/workflows/python-packages.yaml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           sparse-checkout: backend/packages/${{ matrix.package }}
+          sparse-checkout-cone-mode: false
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Cone mode keeps all the files on the way in, including the top-level pyproject.toml, which I'd rather we get rid of.