### PR TITLE
Facilitate using phases in the backend

### DIFF
--- a/backend/Dockerfile.local
+++ b/backend/Dockerfile.local
@@ -13,11 +13,11 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
-RUN uv sync --no-install-project
+RUN uv sync --no-install-project --no-editable
 
 COPY . .
 
-RUN uv sync
+RUN uv sync --no-editable
 
 USER 1001
 
@@ -25,4 +25,4 @@ ENV UV_NO_CACHE=1
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-CMD ["uv", "run", "uvicorn", "acidwatch_api.app:app", "--host", "0.0.0.0", "--port", "8001", "--reload"]
+CMD ["uv", "run", "--no-sync", "uvicorn", "acidwatch_api.app:app", "--host", "0.0.0.0", "--port", "8001", "--reload"]

--- a/backend/alembic/versions/b5d2e3f14a70_replace_concentrations_with_phases.py
+++ b/backend/alembic/versions/b5d2e3f14a70_replace_concentrations_with_phases.py
@@ -1,0 +1,46 @@
+"""replace concentrations with phases
+
+Revision ID: b5d2e3f14a70
+Revises: a3f8b2c91d40
+Create Date: 2026-06-17 00:00:00.000000
+
+Renames the ``concentrations`` JSON column to ``phases`` on both
+``simulations`` and ``results``, and transforms existing flat
+concentration dicts into the new phase-list structure:
+
+    {"H2O": 500} → [{"kind": "co2-rich", "fraction": 1.0, "concentrations": {"H2O": 500}}]
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "b5d2e3f14a70"
+down_revision: Union[str, Sequence[str], None] = "a3f8b2c91d40"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    for table in ("simulations", "results"):
+        op.alter_column(table, "concentrations", new_column_name="phases")
+        op.execute(f"""
+            UPDATE {table}
+            SET phases = jsonb_build_array(
+                jsonb_build_object(
+                    'kind', 'co2-rich',
+                    'fraction', 1.0,
+                    'concentrations', phases::jsonb
+                )
+            )::json
+        """)
+
+
+def downgrade() -> None:
+    for table in ("simulations", "results"):
+        op.execute(f"""
+            UPDATE {table}
+            SET phases = (phases::jsonb -> 0 -> 'concentrations')::json
+        """)
+        op.alter_column(table, "phases", new_column_name="concentrations")

--- a/backend/src/acidwatch_api/database.py
+++ b/backend/src/acidwatch_api/database.py
@@ -43,7 +43,7 @@ class Simulation(Base):
     __tablename__ = "simulations"
 
     owner_id: Mapped[UUID | None] = mapped_column(Uuid)
-    concentrations: Mapped[dict[str, float]] = mapped_column(JSON)
+    phases: Mapped[list[dict]] = mapped_column(JSON)
     conditions: Mapped[dict[str, float] | None] = mapped_column(JSON)
 
     model_inputs: Mapped[list[ModelInput]] = relationship(back_populates="simulation")
@@ -70,7 +70,7 @@ class ModelResult(Base):
     model_input_id: Mapped[UUID] = mapped_column(
         ForeignKey("model_inputs.id"), unique=True
     )
-    concentrations: Mapped[dict[str, float]] = mapped_column(JSON)
+    phases: Mapped[list[dict]] = mapped_column(JSON)
     panels: Mapped[list[Any]] = mapped_column(JSON)
     error: Mapped[str | None] = mapped_column()
 

--- a/backend/src/acidwatch_api/models/arcs.py
+++ b/backend/src/acidwatch_api/models/arcs.py
@@ -4,6 +4,7 @@ from acidwatch_api.models.base import (
     BaseAdapter,
     RunResult,
 )
+from acidwatch_api.models.datamodel import Phase
 from acidwatch_api.settings import SETTINGS
 
 DESCRIPTION: str = """Automated Reactions for CO2 Storage (ARCS) model.
@@ -82,9 +83,15 @@ class ArcsAdapter(BaseAdapter):
             for k, v in stats["index"].items()
         ]
 
-        return {
-            k: v * 1e6 for k, v in result["results"]["final_concs"].items()
-        }, ReactionPathsResult(
+        return [
+            Phase(
+                kind="co2-rich",
+                fraction=1.0,
+                concentrations={
+                    k: v * 1e6 for k, v in result["results"]["final_concs"].items()
+                },
+            )
+        ], ReactionPathsResult(
             common_paths=common_paths,
             stats=all_stats,
         )

--- a/backend/src/acidwatch_api/models/arcs_exp.py
+++ b/backend/src/acidwatch_api/models/arcs_exp.py
@@ -2,6 +2,7 @@ from acidwatch_api.models.base import (
     BaseAdapter,
     RunResult,
 )
+from acidwatch_api.models.datamodel import Phase
 from acidwatch_api.settings import SETTINGS
 
 DESCRIPTION: str = """Automated Reactions for CO2 Storage (ARCS) model.
@@ -63,4 +64,10 @@ class ArcsExpAdapter(BaseAdapter):
 
         result = response.json()
 
-        return {k: v * 1e6 for k, v in result["results"].items()}
+        return [
+            Phase(
+                kind="co2-rich",
+                fraction=1.0,
+                concentrations={k: v * 1e6 for k, v in result["results"].items()},
+            )
+        ]

--- a/backend/src/acidwatch_api/models/base.py
+++ b/backend/src/acidwatch_api/models/base.py
@@ -31,7 +31,7 @@ from pydantic.config import JsonDict
 from typing_extensions import Doc
 
 from acidwatch_api.authentication import acquire_token_for_downstream_api
-from acidwatch_api.models.datamodel import AnyPanel, Conditions
+from acidwatch_api.models.datamodel import AnyPanel, Conditions, Phase
 
 
 class InputError(ValueError):
@@ -44,20 +44,18 @@ Concs: TypeAlias = dict[Compound, float | None]
 Settings: TypeAlias = dict[str, str]
 Metadata: TypeAlias = dict[str, Any]
 ParamType: TypeAlias = int | float | bool | str | AnyPanel
-RunResult: TypeAlias = (
-    dict[str, float | int] | tuple[dict[str, float | int], *tuple[AnyPanel, ...]]
-)
+RunResult: TypeAlias = list[Phase] | tuple[list[Phase], *tuple[AnyPanel, ...]]
 T = TypeVar("T", bound=int | float | bool | str)
 
 
-def get_concs(result: RunResult) -> dict[str, int | float]:
-    if isinstance(result, dict):
+def get_phases(result: RunResult) -> list[Phase]:
+    if isinstance(result, list):
         return result
     return result[0]
 
 
 def get_metas(result: RunResult) -> list[AnyPanel]:
-    if isinstance(result, dict):
+    if isinstance(result, list):
         return []
     return list(result[1:])
 

--- a/backend/src/acidwatch_api/models/datamodel.py
+++ b/backend/src/acidwatch_api/models/datamodel.py
@@ -29,14 +29,20 @@ class Conditions(_BaseModel):
     pressure: float = 10
 
 
-class Simulation(_BaseModel):
+class Phase(_BaseModel):
+    kind: Literal["aqueous", "co2-rich"]
+    fraction: float
     concentrations: dict[str, int | float]
+
+
+class Simulation(_BaseModel):
+    phases: list[Phase]
     conditions: Conditions = Field(default_factory=Conditions)
     models: list[ModelInput] = Field(min_length=1)
 
 
 class ModelResult(_BaseModel):
-    concentrations: dict[str, int | float]
+    phases: list[Phase]
     panels: list[AnyPanel]
 
 

--- a/backend/src/acidwatch_api/models/datamodel.py
+++ b/backend/src/acidwatch_api/models/datamodel.py
@@ -36,9 +36,15 @@ class Phase(_BaseModel):
 
 
 class Simulation(_BaseModel):
-    phases: list[Phase]
+    concentrations: dict[str, int | float]
     conditions: Conditions = Field(default_factory=Conditions)
     models: list[ModelInput] = Field(min_length=1)
+
+    @property
+    def phases(self) -> list[Phase]:
+        return [
+            Phase(kind="co2-rich", fraction=1.0, concentrations=self.concentrations)
+        ]
 
 
 class ModelResult(_BaseModel):

--- a/backend/src/acidwatch_api/models/example_adapter.py
+++ b/backend/src/acidwatch_api/models/example_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from acidwatch_api.models.base import BaseAdapter, BaseParameters, Parameter
+from acidwatch_api.models.base import BaseAdapter, BaseParameters, Parameter, RunResult
+from acidwatch_api.models.datamodel import Phase
 
 
 class ExampleParameters(BaseParameters):
@@ -49,9 +50,11 @@ class ExampleAdapter(BaseAdapter):
 
     parameters: ExampleParameters
 
-    async def run(self) -> dict[str, float]:
+    async def run(self) -> RunResult:
         # At this point the adapter can do whatever they want with the
         # concentrations. The first returned object is considered the output
         # concentrations and must be of the same type as self.concentrations
         # (dict[str, number]), and the unit of number must be in ppm.
-        return self.concentrations
+        return [
+            Phase(kind="co2-rich", fraction=1.0, concentrations=self.concentrations)
+        ]

--- a/backend/src/acidwatch_api/models/gibbs_minimization_model.py
+++ b/backend/src/acidwatch_api/models/gibbs_minimization_model.py
@@ -8,6 +8,7 @@ from acidwatch_api.models.base import (
     Parameter,
     RunResult,
 )
+from acidwatch_api.models.datamodel import Phase
 
 # Model constants
 # Damping factor for composition convergence in Gibbs reactor
@@ -236,4 +237,4 @@ class GibbsMinimizationModelAdapter(BaseAdapter):
 
         # Return results in expected format
         # Return as tuple (final_concentrations, ReactionPathsResult) for RunResponse
-        return dict(results)
+        return [Phase(kind="co2-rich", fraction=1.0, concentrations=dict(results))]

--- a/backend/src/acidwatch_api/models/phpitz_reactive.py
+++ b/backend/src/acidwatch_api/models/phpitz_reactive.py
@@ -4,7 +4,7 @@ from acidwatch_api.models.base import (
     BaseAdapter,
     RunResult,
 )
-from acidwatch_api.models.datamodel import TextResult
+from acidwatch_api.models.datamodel import Phase, TextResult
 from acidwatch_api.settings import SETTINGS
 
 
@@ -61,4 +61,7 @@ class PhpitzReactiveAdapter(BaseAdapter):
             if component != "CO2"
         }
 
-        return (final_concentrations, TextResult(data=data["raw"]))
+        return (
+            [Phase(kind="co2-rich", fraction=1.0, concentrations=final_concentrations)],
+            TextResult(data=data["raw"]),
+        )

--- a/backend/src/acidwatch_api/models/phpitz_solubility.py
+++ b/backend/src/acidwatch_api/models/phpitz_solubility.py
@@ -55,4 +55,4 @@ class PhpitzSolubilityAdapter(BaseAdapter):
 
         data = res.json()
 
-        return {}, TextResult(data=data["raw"], label="pHPitz Solubility Output")
+        return [], TextResult(data=data["raw"], label="pHPitz Solubility Output")

--- a/backend/src/acidwatch_api/models/solubilityccs.py
+++ b/backend/src/acidwatch_api/models/solubilityccs.py
@@ -68,4 +68,4 @@ class SolubilityCCSAdapter(BaseAdapter):
         results_obj = ModelResults(fluid, co2_properties=co2_properties)
         table = results_obj.generate_table()
 
-        return {}, TextResult(data=table, label="Solubility Output")
+        return [], TextResult(data=table, label="Solubility Output")

--- a/backend/src/acidwatch_api/models/tocomo.py
+++ b/backend/src/acidwatch_api/models/tocomo.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from acidwatch_api.models.base import BaseAdapter, RunResult
-from acidwatch_api.models.datamodel import TableResult
+from acidwatch_api.models.datamodel import Phase, TableResult
 from fastapi import APIRouter
 from acidwatch_api.settings import SETTINGS
 
@@ -53,6 +53,14 @@ class TocomoAdapter(BaseAdapter):
         result = res.json()
 
         return (
-            {key.upper(): value for key, value in result["final"].items()},
+            [
+                Phase(
+                    kind="co2-rich",
+                    fraction=1.0,
+                    concentrations={
+                        key.upper(): value for key, value in result["final"].items()
+                    },
+                )
+            ],
             TableResult(data=result["steps"], label="Reaction Steps"),
         )

--- a/backend/src/acidwatch_api/routes/models.py
+++ b/backend/src/acidwatch_api/routes/models.py
@@ -20,6 +20,7 @@ from acidwatch_api.models.datamodel import (
     ModelInfo,
     ModelInput,
     ModelResult,
+    Phase,
     Simulation,
     SimulationResult,
 )
@@ -98,6 +99,19 @@ def get_models(
     return models
 
 
+def _phases_to_concentrations(phases: list[Phase]) -> dict[str, int | float]:
+    merged: dict[str, int | float] = {}
+    for phase in phases:
+        merged.update(phase.concentrations)
+    return merged
+
+
+def _concentrations_to_phases(
+    concentrations: dict[str, int | float],
+) -> list[dict]:
+    return [{"kind": "co2-rich", "fraction": 1.0, "concentrations": concentrations}]
+
+
 async def _run_adapters(
     sessionmaker: SessionMaker,
     concentrations: dict[str, int | float],
@@ -128,7 +142,7 @@ async def _run_adapter(
 
         result_obj = db.ModelResult(
             model_input_id=model_input_id,
-            concentrations=concs,
+            phases=_concentrations_to_phases(concs),
             panels=[p.model_dump(mode="json", by_alias=True) for p in panels],
             error=None,
         )
@@ -144,7 +158,7 @@ async def _run_adapter(
         )
         result_obj = db.ModelResult(
             model_input_id=model_input_id,
-            concentrations={},
+            phases=[],
             panels=[],
             error=f"{type(exc).__name__}: {exc}",
         )
@@ -204,13 +218,13 @@ def get_result_for_simulation(
 
         results.append(
             ModelResult(
-                concentrations=result.concentrations,
+                phases=[Phase(**p) for p in result.phases],
                 panels=result.panels,
             )
         )
 
     simulation_input = Simulation(
-        concentrations=db_simulation.concentrations,
+        phases=db_simulation.phases,
         conditions=Conditions(**(db_simulation.conditions or {})),
         models=model_inputs,
     )
@@ -225,7 +239,7 @@ def get_result_for_simulation(
         input=simulation_input,
         results=[
             ModelResult(
-                concentrations=result.concentrations,
+                phases=result.phases,
                 panels=[
                     TypeAdapter(AnyPanel).validate_python(panel)
                     for panel in result.panels
@@ -268,8 +282,9 @@ async def run_simulation(
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=exc.args)
 
+    concentrations = _phases_to_concentrations(create_simulation.phases)
     try:
-        adapters[0].validate_concentrations(create_simulation.concentrations)
+        adapters[0].validate_concentrations(concentrations)
     except InputError as exc:
         raise HTTPException(status_code=422, detail=exc.detail)
 
@@ -289,7 +304,7 @@ async def run_simulation(
 
     simulation = db.Simulation(
         owner_id=UUID(user.id) if user else None,
-        concentrations=create_simulation.concentrations,
+        phases=[p.model_dump() for p in create_simulation.phases],
         conditions=create_simulation.conditions.model_dump(),
         model_inputs=model_inputs,
     )
@@ -299,7 +314,7 @@ async def run_simulation(
         background_tasks.add_task(
             _run_adapters,
             request.state.session,
-            create_simulation.concentrations,
+            concentrations,
             adapters,
             [model_input.id for model_input in simulation.model_inputs],
         )

--- a/backend/src/acidwatch_api/routes/models.py
+++ b/backend/src/acidwatch_api/routes/models.py
@@ -219,7 +219,9 @@ def get_result_for_simulation(
         )
 
     simulation_input = Simulation(
-        phases=db_simulation.phases,
+        concentrations=_phases_to_concentrations(
+            [Phase(**p) for p in db_simulation.phases]
+        ),
         conditions=Conditions(**(db_simulation.conditions or {})),
         models=model_inputs,
     )
@@ -277,7 +279,7 @@ async def run_simulation(
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=exc.args)
 
-    concentrations = _phases_to_concentrations(create_simulation.phases)
+    concentrations = create_simulation.concentrations
     try:
         adapters[0].validate_concentrations(concentrations)
     except InputError as exc:

--- a/backend/src/acidwatch_api/routes/models.py
+++ b/backend/src/acidwatch_api/routes/models.py
@@ -102,14 +102,9 @@ def get_models(
 def _phases_to_concentrations(phases: list[Phase]) -> dict[str, int | float]:
     merged: dict[str, int | float] = {}
     for phase in phases:
-        merged.update(phase.concentrations)
+        if phase.kind == "co2-rich":
+            merged.update(phase.concentrations)
     return merged
-
-
-def _concentrations_to_phases(
-    concentrations: dict[str, int | float],
-) -> list[dict]:
-    return [{"kind": "co2-rich", "fraction": 1.0, "concentrations": concentrations}]
 
 
 async def _run_adapters(
@@ -133,21 +128,21 @@ async def _run_adapter(
     try:
         result = await adapter.run()
 
-        concs: dict[str, int | float]
+        phases: list[Phase]
         panels: list[AnyPanel] = []
-        if isinstance(result, dict):
-            concs = result
+        if isinstance(result, list):
+            phases = result
         else:
-            concs, *panels = result
+            phases, *panels = result
 
         result_obj = db.ModelResult(
             model_input_id=model_input_id,
-            phases=_concentrations_to_phases(concs),
+            phases=[p.model_dump() for p in phases],
             panels=[p.model_dump(mode="json", by_alias=True) for p in panels],
             error=None,
         )
 
-        return concs
+        return _phases_to_concentrations(phases)
     except BaseException as exc:
         # Full traceback goes to logs (App Insights); only a short message
         # is persisted for surfacing to the API caller.

--- a/backend/tests/test_models_endpoints.py
+++ b/backend/tests/test_models_endpoints.py
@@ -9,7 +9,7 @@ from acidwatch_api.app import fastapi_app
 from acidwatch_api.authentication import authenticated_user_claims
 from acidwatch_api.models import base
 from acidwatch_api.models.base import BaseParameters, Parameter
-from acidwatch_api.models.datamodel import JsonResult
+from acidwatch_api.models.datamodel import JsonResult, Phase
 import acidwatch_api.database as db
 
 
@@ -54,7 +54,15 @@ class DummyAdapter(base.BaseAdapter):
     valid_substances = ["H2O"]
 
     async def run(self):
-        return {key: value / 2 for key, value in self.concentrations.items()}
+        return [
+            Phase(
+                kind="co2-rich",
+                fraction=1.0,
+                concentrations={
+                    key: value / 2 for key, value in self.concentrations.items()
+                },
+            )
+        ]
 
 
 class SecondDummyAdapter(base.BaseAdapter):
@@ -65,7 +73,15 @@ class SecondDummyAdapter(base.BaseAdapter):
     valid_substances = ["H2O"]
 
     async def run(self):
-        return {key: value * 4 for key, value in self.concentrations.items()}
+        return [
+            Phase(
+                kind="co2-rich",
+                fraction=1.0,
+                concentrations={
+                    key: value * 4 for key, value in self.concentrations.items()
+                },
+            )
+        ]
 
 
 class FailingDummyAdapter(base.BaseAdapter):
@@ -176,7 +192,9 @@ class _DummyModelParametersEnum(BaseParameters):
 
 def test_dummy_has_correct_parameter_name(client, monkeypatch, dummy_model):
     async def run(self):
-        return self.concentrations, JsonResult(data=self.parameters)
+        return [
+            Phase(kind="co2-rich", fraction=1.0, concentrations=self.concentrations)
+        ], JsonResult(data=self.parameters)
 
     monkeypatch.setitem(
         dummy_model.__annotations__, "parameters", _DummyModelParameters
@@ -288,7 +306,9 @@ def test_dummy_model_only_valid_parameters_are_present(
     client, monkeypatch, dummy_model, parameters_class, input_parameters, expected
 ):
     async def run(self):
-        return self.concentrations, JsonResult(data=self.parameters)
+        return [
+            Phase(kind="co2-rich", fraction=1.0, concentrations=self.concentrations)
+        ], JsonResult(data=self.parameters)
 
     if parameters_class is not None:
         monkeypatch.setitem(dummy_model.__annotations__, "parameters", parameters_class)

--- a/backend/tests/test_models_endpoints.py
+++ b/backend/tests/test_models_endpoints.py
@@ -138,7 +138,7 @@ def test_dummy_model_only_valid_substances_are_present(
 ):
     monkeypatch.setattr(dummy_model, "valid_substances", valid_substances)
     simulation = {
-        "phases": _make_phases(concentrations),
+        "concentrations": concentrations,
         "models": [{"modelId": dummy_model.model_id, "parameters": {}}],
     }
     response = client.post(
@@ -317,7 +317,7 @@ def test_dummy_model_only_valid_parameters_are_present(
     response = client.post(
         "/simulations/",
         json={
-            "phases": _make_phases({}),
+            "concentrations": {},
             "models": [
                 {"modelId": dummy_model.model_id, "parameters": input_parameters}
             ],
@@ -340,7 +340,7 @@ def test_dummy_model_only_valid_parameters_are_present(
         assert response.json() == {
             "status": "done",
             "input": {
-                "phases": _make_phases({}),
+                "concentrations": {},
                 "conditions": {"temperature": 25.0, "pressure": 10.0},
                 "models": [
                     {
@@ -367,7 +367,7 @@ def test_dummy_model_only_valid_parameters_are_present(
 def test_running_empty_list_of_models_is_an_error(client):
     response = client.post(
         "/simulations",
-        json={"phases": _make_phases({"H2O": 2.0}), "models": []},
+        json={"concentrations": {"H2O": 2.0}, "models": []},
     )
     assert response.status_code == 422
 
@@ -401,7 +401,7 @@ def test_running_empty_list_of_models_is_an_error(client):
 )
 def test_running_models(client, input_models, result_concentrations):
     simulation_input = {
-        "phases": _make_phases({"H2O": 1}),
+        "concentrations": {"H2O": 1},
         "models": input_models,
     }
 
@@ -452,7 +452,7 @@ def test_running_models(client, input_models, result_concentrations):
 )
 def test_failing_model(client, input_models, result):
     simulation_input = {
-        "phases": _make_phases({"H2O": 1}),
+        "concentrations": {"H2O": 1},
         "models": input_models,
     }
 
@@ -530,7 +530,7 @@ def test_results_order(client, sql_session, swap):
     assert response.json() == {
         "status": "done",
         "input": {
-            "phases": _make_phases({}),
+            "concentrations": {},
             "conditions": {"temperature": 25.0, "pressure": 10.0},
             "models": [first_model, second_model],
         },

--- a/backend/tests/test_models_endpoints.py
+++ b/backend/tests/test_models_endpoints.py
@@ -105,6 +105,10 @@ def test_get_test_model(client):
     assert response[0]["modelId"] == "dummy"
 
 
+def _make_phases(concentrations: dict[str, int | float]) -> list[dict]:
+    return [{"kind": "co2-rich", "fraction": 1.0, "concentrations": concentrations}]
+
+
 @pytest.mark.parametrize(
     "valid_substances,concentrations,expected_concs",
     [
@@ -118,7 +122,7 @@ def test_dummy_model_only_valid_substances_are_present(
 ):
     monkeypatch.setattr(dummy_model, "valid_substances", valid_substances)
     simulation = {
-        "concentrations": concentrations,
+        "phases": _make_phases(concentrations),
         "models": [{"modelId": dummy_model.model_id, "parameters": {}}],
     }
     response = client.post(
@@ -141,7 +145,7 @@ def test_dummy_model_only_valid_substances_are_present(
                 **simulation,
                 "conditions": {"temperature": 25.0, "pressure": 10.0},
             },
-            "results": [{"concentrations": expected_concs, "panels": []}],
+            "results": [{"phases": _make_phases(expected_concs), "panels": []}],
         }
 
 
@@ -293,7 +297,7 @@ def test_dummy_model_only_valid_parameters_are_present(
     response = client.post(
         "/simulations/",
         json={
-            "concentrations": {},
+            "phases": _make_phases({}),
             "models": [
                 {"modelId": dummy_model.model_id, "parameters": input_parameters}
             ],
@@ -316,7 +320,7 @@ def test_dummy_model_only_valid_parameters_are_present(
         assert response.json() == {
             "status": "done",
             "input": {
-                "concentrations": {},
+                "phases": _make_phases({}),
                 "conditions": {"temperature": 25.0, "pressure": 10.0},
                 "models": [
                     {
@@ -327,7 +331,7 @@ def test_dummy_model_only_valid_parameters_are_present(
             },
             "results": [
                 {
-                    "concentrations": {"H2O": 0.0},
+                    "phases": _make_phases({"H2O": 0.0}),
                     "panels": [
                         {
                             "type": "json",
@@ -343,7 +347,7 @@ def test_dummy_model_only_valid_parameters_are_present(
 def test_running_empty_list_of_models_is_an_error(client):
     response = client.post(
         "/simulations",
-        json={"concentrations": {"H2O": 2.0}, "models": []},
+        json={"phases": _make_phases({"H2O": 2.0}), "models": []},
     )
     assert response.status_code == 422
 
@@ -377,7 +381,7 @@ def test_running_empty_list_of_models_is_an_error(client):
 )
 def test_running_models(client, input_models, result_concentrations):
     simulation_input = {
-        "concentrations": {"H2O": 1},
+        "phases": _make_phases({"H2O": 1}),
         "models": input_models,
     }
 
@@ -399,7 +403,9 @@ def test_running_models(client, input_models, result_concentrations):
             **simulation_input,
             "conditions": {"temperature": 25.0, "pressure": 10.0},
         },
-        "results": [{"concentrations": x, "panels": []} for x in result_concentrations],
+        "results": [
+            {"phases": _make_phases(x), "panels": []} for x in result_concentrations
+        ],
     }
 
 
@@ -426,7 +432,7 @@ def test_running_models(client, input_models, result_concentrations):
 )
 def test_failing_model(client, input_models, result):
     simulation_input = {
-        "concentrations": {"H2O": 1},
+        "phases": _make_phases({"H2O": 1}),
         "models": input_models,
     }
 
@@ -454,8 +460,8 @@ def test_failing_model(client, input_models, result):
 def test_results_order(client, sql_session, swap):
     first_model = {"modelId": "first_model", "parameters": {}}
     second_model = {"modelId": "second_model", "parameters": {}}
-    first_result = {"concentrations": {"A": 1}, "panels": []}
-    second_result = {"concentrations": {"B": 2}, "panels": []}
+    first_result = {"phases": _make_phases({"A": 1}), "panels": []}
+    second_result = {"phases": _make_phases({"B": 2}), "panels": []}
     first = 0
     second = 1
 
@@ -466,13 +472,13 @@ def test_results_order(client, sql_session, swap):
 
     simulation = db.Simulation(
         owner_id=None,
-        concentrations={},
+        phases=_make_phases({}),
         model_inputs=[
             db.ModelInput(
                 model_id="first_model",
                 parameters={},
                 result=db.ModelResult(
-                    concentrations={"A": 1},
+                    phases=_make_phases({"A": 1}),
                     panels=[],
                     error=None,
                 ),
@@ -481,7 +487,7 @@ def test_results_order(client, sql_session, swap):
                 model_id="second_model",
                 parameters={},
                 result=db.ModelResult(
-                    concentrations={"B": 2},
+                    phases=_make_phases({"B": 2}),
                     panels=[],
                     error=None,
                 ),
@@ -504,7 +510,7 @@ def test_results_order(client, sql_session, swap):
     assert response.json() == {
         "status": "done",
         "input": {
-            "concentrations": {},
+            "phases": _make_phases({}),
             "conditions": {"temperature": 25.0, "pressure": 10.0},
             "models": [first_model, second_model],
         },

--- a/frontend/src/components/ParityPlots.tsx
+++ b/frontend/src/components/ParityPlots.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Button, NativeSelect, Typography } from "@equinor/eds-core-react";
 import ScatterPlot, { ScatterDataSet } from "@/components/ScatterPlot";
 import { ExperimentResult } from "@/dto/ExperimentResult";
-import { SimulationResults } from "@/dto/SimulationResults";
+import { SimulationResults, getCo2RichConcentrations } from "@/dto/SimulationResults";
 
 const buildParityDatasets = (
     experiments: ExperimentResult[],
@@ -16,7 +16,7 @@ const buildParityDatasets = (
         const simulations = simulationsPerExperiment[exp.name] ?? [];
         simulations.forEach((sim) => {
             const modelId = sim.input.models[0].modelId;
-            const modelled = sim.results[0]?.concentrations?.[component] ?? 0;
+            const modelled = getCo2RichConcentrations(sim.results[0]?.phases)[component] ?? 0;
             (byModel[modelId] ??= []).push({ x: measured, y: modelled });
         });
     });

--- a/frontend/src/components/Simulation/MassBalanceError.tsx
+++ b/frontend/src/components/Simulation/MassBalanceError.tsx
@@ -1,5 +1,6 @@
 import { Accordion, Card, Table, Typography } from "@equinor/eds-core-react";
 import { useEffect, useState } from "react";
+import { Phase } from "@/dto/SimulationResults";
 
 const ERROR_THRESHOLD = 1e-3;
 
@@ -127,13 +128,24 @@ export function getMassBalanceError(
     return { error, initMasses, finalMasses, substances };
 }
 
-interface MassBalanceErrorProps {
-    initial: Record<string, number>;
-    final: Record<string, number>;
+export function mergePhasesConcentrations(phases: Phase[]): Record<string, number> {
+    const merged: Record<string, number> = {};
+    for (const phase of phases) {
+        for (const [substance, conc] of Object.entries(phase.concentrations)) {
+            merged[substance] = (merged[substance] ?? 0) + conc * phase.fraction;
+        }
+    }
+    return merged;
 }
 
-export function MassBalanceError({ initial, final }: MassBalanceErrorProps) {
+interface MassBalanceErrorProps {
+    initial: Record<string, number>;
+    phases: Phase[];
+}
+
+export function MassBalanceError({ initial, phases }: MassBalanceErrorProps) {
     const [isExpanded, setExpanded] = useState<boolean>(false);
+    const final = mergePhasesConcentrations(phases);
     const { error, initMasses, finalMasses, substances } = getMassBalanceError(initial, final);
     const significantError = error >= 1;
 

--- a/frontend/src/components/Simulation/Results.tsx
+++ b/frontend/src/components/Simulation/Results.tsx
@@ -69,26 +69,23 @@ const Results: React.FC<ResultsProps> = ({ simulationResults }) => {
         const modelId = simulationResults.input.models[modelIndex]?.modelId || `Model ${modelIndex + 1}`;
         const modelPrefix = simulationResults.results.length > 1 ? `${modelId}: ` : "";
 
-        const hasConcentrations = Object.keys(result.concentrations).length > 0;
-        if (hasConcentrations) {
-            panelTabs.push(`${modelPrefix}Output concentrations`);
+        for (const phase of result.phases) {
+            const hasConcentrations = Object.keys(phase.concentrations).length > 0;
+            if (!hasConcentrations) continue;
 
-            // For the first model, compare with input concentrations
-            // For subsequent models, compare with previous model's output
-            const initialConcentrations =
-                modelIndex === 0
-                    ? simulationResults.input.concentrations
-                    : simulationResults.results[modelIndex - 1].concentrations;
+            panelTabs.push(`${modelPrefix}${phase.kind} (${(phase.fraction * 100).toFixed(1)}%)`);
+
+            const initialConcentrations = simulationResults.input.concentrations;
 
             panelContents.push(
-                <Tabs.Panel key={`conc-${modelIndex}`}>
-                    <MassBalanceError initial={initialConcentrations} final={result.concentrations} />
+                <Tabs.Panel key={`phase-${modelIndex}-${phase.kind}`}>
+                    <MassBalanceError initial={initialConcentrations} phases={result.phases} />
 
                     <BarChart
                         aspectRatio={2}
                         graphData={extractPlotData({
                             ...simulationResults,
-                            results: [result],
+                            results: [{ phases: [phase], panels: [] }],
                             input: {
                                 ...simulationResults.input,
                                 concentrations: initialConcentrations,
@@ -100,7 +97,7 @@ const Results: React.FC<ResultsProps> = ({ simulationResults }) => {
 
                     <ResultConcTable
                         initialConcentrations={initialConcentrations}
-                        finalConcentrations={result.concentrations}
+                        finalConcentrations={phase.concentrations}
                     />
                 </Tabs.Panel>
             );

--- a/frontend/src/dto/SimulationResults.ts
+++ b/frontend/src/dto/SimulationResults.ts
@@ -29,12 +29,25 @@ const TablePanel = z.object({
 export const Panel = z.discriminatedUnion("type", [TextPanel, JsonPanel, ReactionPathsPanel, TablePanel]);
 export type Panel = z.infer<typeof Panel>;
 
+export const Phase = z.object({
+    kind: z.enum(["aqueous", "co2-rich"]),
+    fraction: z.number(),
+    concentrations: z.record(z.string(), z.number()),
+});
+export type Phase = z.infer<typeof Phase>;
+
+export const getCo2RichPhase = (phases: Phase[] = []): Phase | undefined =>
+    phases.find((phase) => phase.kind === "co2-rich");
+
+export const getCo2RichConcentrations = (phases: Phase[] = []): Record<string, number> =>
+    getCo2RichPhase(phases)?.concentrations ?? {};
+
 export const SimulationResults = z.object({
     status: z.enum(["done", "pending"]),
     input: ModelInput,
     results: z.array(
         z.object({
-            concentrations: z.record(z.string(), z.number()),
+            phases: z.array(Phase),
             panels: z.array(Panel),
         })
     ),

--- a/frontend/src/functions/Formatting.tsx
+++ b/frontend/src/functions/Formatting.tsx
@@ -1,4 +1,4 @@
-import { SimulationResults } from "@/dto/SimulationResults";
+import { SimulationResults, getCo2RichConcentrations } from "@/dto/SimulationResults";
 import { ChartDataSet, TabulatedResultRow } from "@/dto/ChartData";
 import { ExperimentResult } from "@/dto/ExperimentResult";
 
@@ -15,7 +15,7 @@ export const convertToSubscripts = (chemicalFormula: string): React.ReactNode =>
 
 export const extractPlotData = (simulationResults: SimulationResults) => {
     const inputConcentrations = simulationResults.input.concentrations;
-    const finalConcentrations = simulationResults.results[0].concentrations;
+    const finalConcentrations = getCo2RichConcentrations(simulationResults.results[0]?.phases);
     const keys = Object.keys(finalConcentrations).filter(
         (key) => (inputConcentrations[key] ?? 0) >= 0.001 || (finalConcentrations[key] ?? 0) >= 0.001
     );
@@ -47,9 +47,10 @@ export const extractPlotData = (simulationResults: SimulationResults) => {
 };
 
 export const convertSimulationToChartData = (simulation: SimulationResults, experimentName: string): ChartDataSet => {
+    const concentrations = getCo2RichConcentrations(simulation.results[0]?.phases);
     return {
         label: `${simulation.input.models[0].modelId} - ${experimentName}`,
-        data: Object.entries(simulation.results[0].concentrations)
+        data: Object.entries(concentrations)
             .filter(([, y]) => y !== 0)
             .map(([x, y]) => ({ x, y })),
     };
@@ -91,7 +92,7 @@ export const convertSimulationQueriesResultToTabulatedData = (
                 buildTabulatedRow(
                     `${simulation.input.models[0].modelId || "Unknown"} - ${experimentName}`,
                     simulation.input.concentrations,
-                    simulation.results[0].concentrations,
+                    getCo2RichConcentrations(simulation.results[0]?.phases),
                     { ...simulation.input.conditions, ...simulation.input.models[0].parameters }
                 )
             );

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -4,7 +4,7 @@ import { useQueries } from "@tanstack/react-query";
 import { getResultForSimulation, ResultIsPending } from "@/api/api";
 import { MainContainer } from "@/components/styles";
 import { Typography, Table, CircularProgress, Banner } from "@equinor/eds-core-react";
-import { SimulationResults } from "@/dto/SimulationResults";
+import { SimulationResults, getCo2RichConcentrations } from "@/dto/SimulationResults";
 import BarChart from "@/components/BarChart";
 import { ChartDataSet } from "@/dto/ChartData";
 
@@ -116,17 +116,14 @@ const Compare: React.FC = () => {
     const simulationResults = queries.map((q) => q.data as SimulationResults);
 
     const comparisons: SimulationComparison[] = simulationResults.map((result, index) => {
-        // Find the last result that has concentrations
-        const finalOutput = [...result.results]
-            .reverse()
-            .find((r) => r.concentrations && Object.keys(r.concentrations).length > 0);
+        const finalResult = [...result.results].reverse().find((r) => r.phases.length > 0);
         const firstModel = result.input.models[0];
 
         return {
             id: simulationIds[index],
             modelName: firstModel?.modelId || "Unknown",
             inputConcentrations: result.input.concentrations || {},
-            outputConcentrations: finalOutput?.concentrations || {},
+            outputConcentrations: getCo2RichConcentrations(finalResult?.phases),
         };
     });
 

--- a/frontend/tests/components/LabResultPlot.test.tsx
+++ b/frontend/tests/components/LabResultPlot.test.tsx
@@ -37,11 +37,21 @@ describe("LabResultsPlot Component", () => {
         "Experiment Gondor": [
             {
                 input: { concentrations: { CO2: 0.5, H2O: 0.3 }, models: [{ parameters: {}, modelId: "Narnia" }] },
-                results: [{ concentrations: { H2CO3: 0.3, N2: 0.9 }, panels: [] }],
+                results: [
+                    {
+                        phases: [{ kind: "co2-rich", fraction: 1.0, concentrations: { H2CO3: 0.3, N2: 0.9 } }],
+                        panels: [],
+                    },
+                ],
             },
             {
                 input: { concentrations: { CO2: 0.5, H2O: 0.3 }, models: [{ parameters: {}, modelId: "Mordor" }] },
-                results: [{ concentrations: { CO: 0.3, NO2: 0.9 }, panels: [] }],
+                results: [
+                    {
+                        phases: [{ kind: "co2-rich", fraction: 1.0, concentrations: { CO: 0.3, NO2: 0.9 } }],
+                        panels: [],
+                    },
+                ],
             },
         ],
     };

--- a/frontend/tests/functions/Formatting.test.tsx
+++ b/frontend/tests/functions/Formatting.test.tsx
@@ -36,7 +36,9 @@ describe("convertToSubscripts", () => {
 describe("convertingSimulationToChartData", () => {
     const simulation: SimulationResults = {
         input: { concentrations: { CO: 0.5, H20: 0.7 }, models: [{ parameters: {}, modelId: "Narnia" }] },
-        results: [{ concentrations: { H2CO3: 0.3, N2: 0.9 }, panels: [] }],
+        results: [
+            { phases: [{ kind: "co2-rich", fraction: 1.0, concentrations: { H2CO3: 0.3, N2: 0.9 } }], panels: [] },
+        ],
     };
     it("converts simulation to chart data correctly", () => {
         const chartData = convertSimulationToChartData(simulation, "Welcome to Narnia");
@@ -58,7 +60,9 @@ describe("Table Data Conversion Functions", () => {
                             concentrations: { O2: 22 },
                             models: [{ modelId: "TOCOMO", parameters: { pressure: 1, temperature: 22 } }],
                         },
-                        results: [{ concentrations: { O2: 32 }, panels: [] }],
+                        results: [
+                            { phases: [{ kind: "co2-rich", fraction: 1.0, concentrations: { O2: 32 } }], panels: [] },
+                        ],
                     },
                 ],
                 Exp2: [
@@ -67,7 +71,9 @@ describe("Table Data Conversion Functions", () => {
                             concentrations: { O2: 22 },
                             models: [{ modelId: "arcs", parameters: { pressure: 1, temperature: 22 } }],
                         },
-                        results: [{ concentrations: { O2: 30 }, panels: [] }],
+                        results: [
+                            { phases: [{ kind: "co2-rich", fraction: 1.0, concentrations: { O2: 30 } }], panels: [] },
+                        ],
                     },
                 ],
             };


### PR DESCRIPTION
So far AcidWatch has only handled a single phase, also for output. A single set of concentrations has been shown, even though some models (solubility and phpitz) provides information on acid dropout (an aqueous phase). We want to facilitate structured data for the output of those models, and also allow for calculating corrosion (which is calculated from the acidic phase).

solves https://github.com/equinor/acidwatch/issues/633