### PR TITLE
Restrict models in labexperiments to reactive only

### DIFF
--- a/frontend/src/pages/LabResults.tsx
+++ b/frontend/src/pages/LabResults.tsx
@@ -20,7 +20,8 @@ import Statuses from "@/components/Statuses";
 import { SimulationResults } from "@/dto/SimulationResults";
 import { MainContainer } from "@/components/styles";
 
-const defaultModels = (models: ModelConfig[]) => new Set(models.map((m) => m.modelId));
+const defaultModels = (models: ModelConfig[]) =>
+    new Set(models.filter((m) => m.category === "Primary").map((m) => m.modelId));
 
 const LabResults: React.FC = () => {
     const [selectedExperiments, setSelectedExperiments] = useState<ExperimentResult[]>([]);


### PR DESCRIPTION
Running only solubility doesn't make sense for this page. We might want
to allow a chain, but in this comparison I think we start with only
reactive for now
