### PR TITLE
Change grid simulation stepping

### DIFF
--- a/backend/src/acidwatch_api/models/datamodel.py
+++ b/backend/src/acidwatch_api/models/datamodel.py
@@ -60,21 +60,31 @@ class SimulationResult(_BaseModel):
 
 
 class AxisRange(_BaseModel):
-    """A linear, inclusive range that is sampled at ``steps`` points."""
+    """A linear, inclusive range from min to max with a given step size."""
 
     min: float
     max: float
-    steps: int = Field(default=10, ge=2, le=25)
+    step: float = Field(default=10, gt=0)
 
     @model_validator(mode="after")
     def _check_bounds(self) -> "AxisRange":
         if self.max <= self.min:
             raise ValueError("max must be greater than min")
+        if self.step > (self.max - self.min):
+            raise ValueError("step must not exceed the range (max - min)")
         return self
 
     def values(self) -> list[float]:
-        step = (self.max - self.min) / (self.steps - 1)
-        return [self.min + step * i for i in range(self.steps)]
+        result = []
+        current = self.min
+        while current <= self.max + 1e-9:
+            result.append(current)
+            current += self.step
+        return result
+
+    @property
+    def num_points(self) -> int:
+        return len(self.values())
 
 
 class Axis(_BaseModel):
@@ -103,7 +113,7 @@ class CreateGridSimulation(_BaseModel):
 
         total = 1
         for axis in self.axes:
-            total *= axis.range.steps
+            total *= axis.range.num_points
         if total > 100:
             raise ValueError(
                 f"Grid too large: {total} points exceeds the maximum of 100"

--- a/backend/tests/test_grid_simulations_endpoint.py
+++ b/backend/tests/test_grid_simulations_endpoint.py
@@ -112,7 +112,7 @@ def dummy_adapters(client):
 
 def _create_grid(client, **overrides):
     body = {
-        "axes": [{"substance": "H2O", "range": {"min": 10, "max": 100, "steps": 10}}],
+        "axes": [{"substance": "H2O", "range": {"min": 10, "max": 100, "step": 10}}],
         "concentrations": {},
         "models": [{"modelId": "halving", "parameters": {}}],
     }
@@ -142,7 +142,7 @@ def test_grid_produces_correct_number_of_points(client):
 def test_grid_points_are_individually_retrievable_simulations(client):
     grid_id = _create_grid(
         client,
-        axes=[{"substance": "H2O", "range": {"min": 10, "max": 20, "steps": 2}}],
+        axes=[{"substance": "H2O", "range": {"min": 10, "max": 20, "step": 5}}],
     ).json()
     result = client.get_json(f"/grid-simulations/{grid_id}/result")
 
@@ -154,7 +154,7 @@ def test_grid_points_are_individually_retrievable_simulations(client):
 def test_grid_runs_full_model_chain(client):
     grid_id = _create_grid(
         client,
-        axes=[{"substance": "H2O", "range": {"min": 5, "max": 10, "steps": 2}}],
+        axes=[{"substance": "H2O", "range": {"min": 5, "max": 10, "step": 5}}],
         models=[
             {"modelId": "halving", "parameters": {}},
             {"modelId": "quadrupling", "parameters": {}},
@@ -194,7 +194,7 @@ def test_grid_rejects_unknown_model(client):
 def test_grid_rejects_unsupported_substance(client):
     response = _create_grid(
         client,
-        axes=[{"substance": "UNKNOWN", "range": {"min": 1, "max": 10, "steps": 2}}],
+        axes=[{"substance": "UNKNOWN", "range": {"min": 1, "max": 10, "step": 5}}],
     )
     assert response.status_code == HTTP_422_UNPROCESSABLE_ENTITY
 
@@ -203,7 +203,7 @@ def test_grid_rejects_unsupported_substance(client):
 def test_grid_rejects_invalid_range(client):
     response = _create_grid(
         client,
-        axes=[{"substance": "H2O", "range": {"min": 100, "max": 10, "steps": 5}}],
+        axes=[{"substance": "H2O", "range": {"min": 100, "max": 10, "step": 5}}],
     )
     assert response.status_code == HTTP_422_UNPROCESSABLE_ENTITY
 
@@ -232,8 +232,8 @@ def test_grid_2d_matrix(client):
     grid_id = _create_grid(
         client,
         axes=[
-            {"substance": "H2O", "range": {"min": 10, "max": 20, "steps": 2}},
-            {"substance": "NaCl", "range": {"min": 100, "max": 200, "steps": 2}},
+            {"substance": "H2O", "range": {"min": 10, "max": 20, "step": 10}},
+            {"substance": "NaCl", "range": {"min": 100, "max": 200, "step": 100}},
         ],
         models=[{"modelId": "two-substance", "parameters": {}}],
     ).json()
@@ -254,8 +254,8 @@ def test_grid_rejects_duplicate_axis_substances(client):
     response = _create_grid(
         client,
         axes=[
-            {"substance": "H2O", "range": {"min": 10, "max": 20, "steps": 2}},
-            {"substance": "H2O", "range": {"min": 100, "max": 200, "steps": 2}},
+            {"substance": "H2O", "range": {"min": 10, "max": 20, "step": 10}},
+            {"substance": "H2O", "range": {"min": 100, "max": 200, "step": 100}},
         ],
     )
     assert response.status_code == HTTP_422_UNPROCESSABLE_ENTITY

--- a/frontend/src/components/Simulation/ModelInputs.tsx
+++ b/frontend/src/components/Simulation/ModelInputs.tsx
@@ -118,17 +118,17 @@ function GridRangeInput({ candidateSubstances }: { candidateSubstances: string[]
 
     const [minStr, setMinStr] = useState(axis?.range.min.toString() ?? "");
     const [maxStr, setMaxStr] = useState(axis?.range.max.toString() ?? "");
-    const [stepsStr, setStepsStr] = useState(axis?.range.steps.toString() ?? "");
+    const [stepStr, setStepStr] = useState(axis?.range.step.toString() ?? "");
 
     useEffect(() => {
         if (axis) {
             setMinStr(axis.range.min.toString());
             setMaxStr(axis.range.max.toString());
-            setStepsStr(axis.range.steps.toString());
+            setStepStr(axis.range.step.toString());
         }
     }, [axis?.substance]);
 
-    const commitRange = (field: "min" | "max" | "steps", raw: string) => {
+    const commitRange = (field: "min" | "max" | "step", raw: string) => {
         if (!axis) return;
         const v = Number(raw);
         if (Number.isNaN(v)) return;
@@ -196,15 +196,15 @@ function GridRangeInput({ candidateSubstances }: { candidateSubstances: string[]
                                     }
                                 />
                                 <TextField
-                                    id="gridSteps0"
+                                    id="gridStep0"
                                     type="number"
-                                    label="Number of values"
-                                    step={1}
-                                    min={2}
-                                    max={25}
-                                    value={stepsStr}
-                                    onChange={(e: ChangeEvent<HTMLInputElement>) => setStepsStr(e.target.value)}
-                                    onBlur={() => commitRange("steps", stepsStr)}
+                                    label="Step"
+                                    unit="ppm"
+                                    step="any"
+                                    min={0.001}
+                                    value={stepStr}
+                                    onChange={(e: ChangeEvent<HTMLInputElement>) => setStepStr(e.target.value)}
+                                    onBlur={() => commitRange("step", stepStr)}
                                 />
                             </>
                         )}
@@ -287,7 +287,7 @@ const ModelInputs: React.FC<{
     const gridableSubstances = Object.keys(concentrations).filter(isSubstanceValid);
     const canRunGrid =
         gridAxes.length > 0 &&
-        gridAxes.every((a) => a.substance !== "" && a.range.max > a.range.min) &&
+        gridAxes.every((a) => a.substance !== "" && a.range.max > a.range.min && a.range.step > 0) &&
         !hasNoValidSubstances;
 
     return (

--- a/frontend/src/dto/GridSimulation.ts
+++ b/frontend/src/dto/GridSimulation.ts
@@ -4,7 +4,7 @@ import { SimulationResults } from "./SimulationResults";
 export const AxisRange = z.object({
     min: z.number(),
     max: z.number(),
-    steps: z.number(),
+    step: z.number(),
 });
 export type AxisRange = z.infer<typeof AxisRange>;
 

--- a/frontend/src/hooks/useGridRangeStore.ts
+++ b/frontend/src/hooks/useGridRangeStore.ts
@@ -1,9 +1,8 @@
 import { create } from "zustand";
 import { Axis } from "@/dto/GridSimulation";
 
-export const DEFAULT_GRID_STEPS = 10;
-const MIN_GRID_STEPS = 2;
-const MAX_GRID_STEPS = 25;
+export const DEFAULT_GRID_STEP = 1;
+const MIN_GRID_STEP = 0.001;
 
 export interface GridRangeState {
     axes: Axis[];
@@ -15,12 +14,11 @@ export interface GridRangeState {
     reset: (state?: { axes?: Axis[] }) => void;
 }
 
-export const clampSteps = (value: number): number =>
-    Math.max(MIN_GRID_STEPS, Math.min(MAX_GRID_STEPS, Math.round(value || DEFAULT_GRID_STEPS)));
+export const clampStep = (value: number): number => Math.max(MIN_GRID_STEP, value || DEFAULT_GRID_STEP);
 
 const DEFAULT_AXIS: Axis = {
     substance: "",
-    range: { min: 0, max: 100, steps: DEFAULT_GRID_STEPS },
+    range: { min: 0, max: 10, step: DEFAULT_GRID_STEP },
 };
 
 export const useGridRangeStore = create<GridRangeState>((set) => ({
@@ -47,7 +45,7 @@ export const useGridRangeStore = create<GridRangeState>((set) => ({
                     updated.range = {
                         ...axis.range,
                         ...partial.range,
-                        steps: clampSteps(partial.range.steps ?? axis.range.steps),
+                        step: clampStep(partial.range.step ?? axis.range.step),
                     };
                 }
                 return updated;


### PR DESCRIPTION
Instead of doing min/max/n-values, we do min/max/stepsize. This makes it easier for users to ensure they get the correct list of numbers (e.g. min/max/n-values with 0/10/1 gave steps of 1.111,2.222 etc)