### PR TITLE
Passthrough invalid components

### DIFF
--- a/backend/src/acidwatch_api/models/base.py
+++ b/backend/src/acidwatch_api/models/base.py
@@ -307,10 +307,38 @@ class BaseAdapter:
         return self._concentrations
 
     def set_concentrations(self, value: dict[str, float | int]) -> None:
+        self._all_concentrations = dict(value)
         self._concentrations = {
             subst: value.get(subst, 0.0)
             for subst in getattr(self, "valid_substances", [])
         }
+
+    @property
+    def passthrough_concentrations(self) -> dict[str, float | int]:
+        return {
+            k: v
+            for k, v in self._all_concentrations.items()
+            if k not in self.valid_substances
+        }
+
+    def merge_passthrough(self, phases: list[Phase]) -> list[Phase]:
+        passthrough = self.passthrough_concentrations
+        if not passthrough:
+            return phases
+
+        merged: list[Phase] = []
+        for phase in phases:
+            if phase.kind == "co2-rich":
+                merged.append(
+                    Phase(
+                        kind=phase.kind,
+                        fraction=phase.fraction,
+                        concentrations={**passthrough, **phase.concentrations},
+                    )
+                )
+            else:
+                merged.append(phase)
+        return merged
 
     def validate_concentrations(self, value: dict[str, float | int]) -> None:
         concentrations_errors = {

--- a/backend/src/acidwatch_api/routes/models.py
+++ b/backend/src/acidwatch_api/routes/models.py
@@ -224,6 +224,8 @@ async def _run_adapter(
         else:
             phases, *panels = result
 
+        phases = adapter.merge_passthrough(phases)
+
         result_obj = db.ModelResult(
             model_input_id=model_input_id,
             phases=[p.model_dump() for p in phases],

--- a/backend/tests/models/test_passthrough.py
+++ b/backend/tests/models/test_passthrough.py
@@ -1,0 +1,93 @@
+import pytest
+from acidwatch_api.models.base import BaseAdapter
+from acidwatch_api.models.datamodel import Phase
+
+
+class DummyAdapter(BaseAdapter):
+    model_id = "dummy"
+    display_name = "Dummy"
+    description = "test"
+    category = "ChemicalEquilibrium"
+    valid_substances = ["CO2", "HCl"]
+
+    async def run(self):
+        return []
+
+
+@pytest.fixture
+def adapter():
+    a = DummyAdapter(parameters=None, jwt_token=None)
+    return a
+
+
+class TestSetConcentrations:
+    def test_filters_to_valid_substances(self, adapter):
+        adapter.set_concentrations({"CO2": 1.0, "HCl": 2.0, "H2O": 3.0})
+        assert adapter.concentrations == {"CO2": 1.0, "HCl": 2.0}
+
+    def test_defaults_missing_valid_substances_to_zero(self, adapter):
+        adapter.set_concentrations({"CO2": 1.0, "H2O": 3.0})
+        assert adapter.concentrations == {"CO2": 1.0, "HCl": 0.0}
+
+
+class TestPassthroughConcentrations:
+    @pytest.mark.parametrize(
+        "input_concs,expected",
+        [
+            ({"CO2": 1.0, "HCl": 2.0}, {}),
+            ({"CO2": 1.0, "H2O": 3.0}, {"H2O": 3.0}),
+            ({"H2O": 3.0, "NaCl": 5.0}, {"H2O": 3.0, "NaCl": 5.0}),
+        ],
+        ids=[
+            "all_handled",
+            "one_unhandled",
+            "all_unhandled",
+        ],
+    )
+    def test_returns_unhandled_components(self, adapter, input_concs, expected):
+        adapter.set_concentrations(input_concs)
+        assert adapter.passthrough_concentrations == expected
+
+
+class TestMergePassthrough:
+    def test_no_passthrough_returns_phases_unchanged(self, adapter):
+        adapter.set_concentrations({"CO2": 1.0, "HCl": 2.0})
+        phases = [Phase(kind="co2-rich", fraction=1.0, concentrations={"CO2": 0.5})]
+        result = adapter.merge_passthrough(phases)
+        assert result is phases
+
+    @pytest.mark.parametrize(
+        "phase_kind,expect_merge",
+        [
+            ("co2-rich", True),
+            ("aqueous", False),
+        ],
+    )
+    def test_only_merges_into_co2_rich_phases(self, adapter, phase_kind, expect_merge):
+        adapter.set_concentrations({"CO2": 1.0, "H2O": 3.0})
+        phases = [Phase(kind=phase_kind, fraction=1.0, concentrations={"CO2": 0.5})]
+        result = adapter.merge_passthrough(phases)
+        if expect_merge:
+            assert result[0].concentrations == {"CO2": 0.5, "H2O": 3.0}
+        else:
+            assert result[0].concentrations == {"CO2": 0.5}
+
+    def test_model_output_takes_precedence_over_passthrough(self, adapter):
+        adapter.set_concentrations({"CO2": 1.0, "H2O": 3.0, "NaCl": 7.0})
+        phases = [
+            Phase(
+                kind="co2-rich", fraction=1.0, concentrations={"CO2": 0.5, "NaCl": 9.0}
+            )
+        ]
+        result = adapter.merge_passthrough(phases)
+        assert result[0].concentrations == {"CO2": 0.5, "H2O": 3.0, "NaCl": 9.0}
+
+    def test_multiple_phases(self, adapter):
+        adapter.set_concentrations({"CO2": 1.0, "H2O": 3.0})
+        phases = [
+            Phase(kind="co2-rich", fraction=0.7, concentrations={"CO2": 0.5}),
+            Phase(kind="aqueous", fraction=0.3, concentrations={"CO2": 0.1}),
+        ]
+        result = adapter.merge_passthrough(phases)
+        assert result[0].concentrations == {"CO2": 0.5, "H2O": 3.0}
+        assert result[1].concentrations == {"CO2": 0.1}


### PR DESCRIPTION
Whenever models where chained, only the components that would be
accepted by a model would be included. Say H2O was an output in model A,
but not a valid component in model B. Then the component would be
ignored as of Model B.

This is especially important whenever we will get another section in the
chain, as otherwise a model in between could end up removing components
for models later.
