### PR TITLE
Revert "Ensure all docker images run update from base image"

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,8 +10,6 @@ RUN uv sync --package acidwatch-api --extra pg --frozen --no-dev --no-editable
 
 FROM python:3.13-slim
 
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
-
 COPY --from=build /app/.venv /app/.venv
 COPY backend/alembic /app/backend/alembic
 COPY backend/alembic.ini backend/entrypoint /app/backend/

--- a/backend/Dockerfile.local
+++ b/backend/Dockerfile.local
@@ -1,7 +1,5 @@
 FROM python:3.12-slim
 
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
-
 ENV UV_NO_CACHE=1
 ENV UV_DYNAMIC_VERSIONING_BYPASS=0.1.0
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,9 +9,6 @@ RUN npm install
 RUN npm run build
 
 FROM docker.io/nginxinc/nginx-unprivileged
-
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY --from=builder /app/dist ./www
 COPY nginx-conf/nginx.conf /etc/nginx/conf.d/default.conf

--- a/frontend/Dockerfile.local
+++ b/frontend/Dockerfile.local
@@ -1,7 +1,5 @@
 FROM docker.io/library/node:22-bookworm-slim
 
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 
 COPY package*.json ./

--- a/workers/arcs-exp/Dockerfile
+++ b/workers/arcs-exp/Dockerfile
@@ -14,8 +14,6 @@ RUN uv sync --project workers/arcs-exp --frozen --no-dev --no-editable
 
 FROM python:3.13-slim
 
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
-
 COPY --from=build /app/.venv /app/.venv
 
 ENV PATH="/app/.venv/bin:$PATH"

--- a/workers/arcs/Dockerfile
+++ b/workers/arcs/Dockerfile
@@ -20,8 +20,6 @@ RUN uv sync --project workers/arcs --frozen --no-dev --no-editable
 
 FROM python:3.13-slim
 
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
-
 COPY --from=build /app/.venv /app/.venv
 
 # the bin and model folders are not included when installing arcs, so even though we added

--- a/workers/example/Dockerfile
+++ b/workers/example/Dockerfile
@@ -11,8 +11,6 @@ RUN uv sync --project workers/example --frozen --no-dev --no-editable
 
 FROM python:3.13-slim
 
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
-
 COPY --from=build /app/.venv /app/.venv
 
 ENV PATH="/app/.venv/bin:$PATH"

--- a/workers/gibbs-minimization/Dockerfile
+++ b/workers/gibbs-minimization/Dockerfile
@@ -12,7 +12,6 @@ RUN uv sync --project workers/gibbs-minimization --frozen --no-dev --no-editable
 FROM python:3.13-slim
 
 RUN apt-get update && \
-    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends openjdk-21-jre-headless && \
     rm -rf /var/lib/apt/lists/*
 

--- a/workers/phpitz-reactive/Dockerfile
+++ b/workers/phpitz-reactive/Dockerfile
@@ -11,8 +11,6 @@ RUN uv sync --project workers/phpitz-reactive --frozen --no-dev --no-editable
 
 FROM python:3.13-slim
 
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
-
 COPY --from=build /app/.venv /app/.venv
 
 ENV PATH="/app/.venv/bin:$PATH"

--- a/workers/phpitz-solubility/Dockerfile
+++ b/workers/phpitz-solubility/Dockerfile
@@ -11,8 +11,6 @@ RUN uv sync --project workers/phpitz-solubility --frozen --no-dev --no-editable
 
 FROM python:3.13-slim
 
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
-
 COPY --from=build /app/.venv /app/.venv
 
 ENV PATH="/app/.venv/bin:$PATH"

--- a/workers/srk-vanlaar/Dockerfile
+++ b/workers/srk-vanlaar/Dockerfile
@@ -12,7 +12,6 @@ RUN uv sync --project workers/srk-vanlaar --frozen --no-dev --no-editable
 FROM python:3.13-slim
 
 RUN apt-get update && \
-    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends openjdk-21-jre-headless && \
     rm -rf /var/lib/apt/lists/*
 

--- a/workers/tocomo/Dockerfile
+++ b/workers/tocomo/Dockerfile
@@ -14,8 +14,6 @@ RUN uv sync --project workers/tocomo --frozen --no-dev --no-editable
 
 FROM python:3.13-slim
 
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
-
 COPY --from=build /app/.venv /app/.venv
 
 ENV PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
Reverted this, it's silly done. The base images are built weekly, with security patches more frequently than that. Doing an apt get in between there has little effect. What I wanted to do was to get rid of scanned vulnerabilities in the build image, albeit those vulnerabilities just haven't been fixed yet I presume. 

This reverts commit dc5979f51b939008f76f504a505cd816c45d41b4.