### PR TITLE
Increase backend memory requirements

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -77,10 +77,10 @@ spec:
           dockerfileName: backend/Dockerfile
           resources:
               requests:
-                  memory: "800M"
+                  memory: "4000M"
                   cpu: "4000m"
               limits:
-                  memory: "800M"
+                  memory: "4000M"
                   cpu: "4000m"
         - name: worker-tocomo
           secrets:


### PR DESCRIPTION
We have gotten OOM kills on backend, the settings were quite low though. Increased quite a bit now and we will monitor going forward.